### PR TITLE
ZON-6143 ff: Add more teaser types

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -154,6 +154,9 @@ components:
           type: string
           nullable: true
           example: "8ed8a6"
+        force_mobile:
+          type: boolean
+          example: false
 
     audio_connection:
       properties:

--- a/api.yaml
+++ b/api.yaml
@@ -346,12 +346,8 @@ components:
             type:
               type: string
               enum:
-                - module
-              example: "module"
-            type:
-              type: string
-              enum:
                 - html
+              example: "html"
             raw_content:
               type: string
               format: html

--- a/api.yaml
+++ b/api.yaml
@@ -403,7 +403,7 @@ components:
               enum:
                 - region
               example: "region"
-            kind:
+            layout:
               type: string
               enum:
                 - standard
@@ -420,7 +420,7 @@ components:
               enum:
                 - area
               example: "area"
-            kind:
+            layout:
               type: string
               enum:
                 - standard

--- a/api.yaml
+++ b/api.yaml
@@ -142,6 +142,20 @@ components:
         - html
       description: "Kind of the cp element"
 
+    audio_connection:
+      properties:
+        id:
+          type: string
+          enum:
+            - itunes
+            - spotify
+            - deezer
+            - alexa
+        url:
+          type: string
+          # format: uri
+          example: "https://podcasts.apple.com/podcast/id1279335230"
+
     CenterpageElement:
       required:
         - id
@@ -327,11 +341,15 @@ components:
                 duration:
                   type: string
                   example: "-00:05:23"
-                source:
+                url:
                   type: string
                   # format: uri
                   description: "URL directly to the audio source"
                   example: "https://cdn.podigee.com/media/podcast_17255_unter_pfarrerstochtern_episode_214511_die_opferung_des_isaak.mp3?v=1588876957&source=webplayer"
+                connections:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/audio_connection"
     CenterpageModuleWeb:
       description: "A non-native module that should be displayed via a web view"
       allOf:

--- a/api.yaml
+++ b/api.yaml
@@ -132,6 +132,16 @@ components:
         - module
       description: "Type of the cp element"
 
+    cp_element_kind:
+      type: string
+      enum:
+        - article
+        - gallery
+        - video
+        - podcast
+        - html
+      description: "Kind of the cp element"
+
     CenterpageElement:
       required:
         - id
@@ -141,6 +151,8 @@ components:
           $ref: "#/components/schemas/cp_element_id"
         type:
           $ref: "#/components/schemas/cp_element_type"
+        kind:
+          $ref: "#/components/schemas/cp_element_kind"
     CenterpageTeaserBase:
       description: "A teaser module references/represents a content object (article, video, etc.)"
       allOf:

--- a/api.yaml
+++ b/api.yaml
@@ -257,6 +257,80 @@ components:
                   # format: uri
                   description: "URL directly to the comment area of the article"
                   example: "https://www.zeit.de/my/article#comments"
+    CenterpageTeaserArticle:
+      description: "A teaser module references/represents an article content object"
+      allOf:
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
+          properties:
+            kind:
+              type: string
+              enum:
+                - article
+    CenterpageTeaserGallery:
+      description: "A teaser module references/represents a gallery content object"
+      allOf:
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
+        - required:
+            - gallery
+          properties:
+            kind:
+              type: string
+              enum:
+                - gallery
+            gallery:
+              type: object
+              properties:
+                label:
+                  type: string
+                  description: "Label to display gallery content"
+                  example: "18 Bilder"
+    CenterpageTeaserVideo:
+      description: "A teaser module references/represents a video content object"
+      allOf:
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
+        - required:
+            - video
+          properties:
+            kind:
+              type: string
+              enum:
+                - video
+            video:
+              type: object
+              properties:
+                id:
+                  type: string
+                  example: "6194436097001"
+                # advertising: bool
+                # provider: "brightcove"
+                # product-id:
+                # page-url:
+                # series: serienname
+    CenterpageTeaserPodcast:
+      description: "A teaser module references/represents an article content object with audio"
+      allOf:
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
+        - required:
+            - audio
+          properties:
+            kind:
+              type: string
+              enum:
+               - podcast
+            audio:
+              type: object
+              properties:
+                color:
+                  type: string
+                  example: "#8ed8a6"
+                duration:
+                  type: string
+                  example: "-00:05:23"
+                source:
+                  type: string
+                  # format: uri
+                  description: "URL directly to the audio source"
+                  example: "https://cdn.podigee.com/media/podcast_17255_unter_pfarrerstochtern_episode_214511_die_opferung_des_isaak.mp3?v=1588876957&source=webplayer"
     CenterpageModuleWeb:
       description: "A non-native module that should be displayed via a web view"
       allOf:
@@ -269,6 +343,10 @@ components:
               enum:
                 - module
               example: "module"
+            kind:
+              type: string
+              enum:
+                - html
             raw_content:
               type: string
               format: html
@@ -323,7 +401,10 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: "#/components/schemas/CenterpageModuleTeaser"
+                  - $ref: "#/components/schemas/CenterpageTeaserArticle"
+                  - $ref: "#/components/schemas/CenterpageTeaserGallery"
+                  - $ref: "#/components/schemas/CenterpageTeaserVideo"
+                  - $ref: "#/components/schemas/CenterpageTeaserPodcast"
                   - $ref: "#/components/schemas/CenterpageModuleWeb"
 
 

--- a/api.yaml
+++ b/api.yaml
@@ -135,7 +135,7 @@ components:
     cp_element_kind:
       type: string
       enum:
-        - article
+        - standard
         - gallery
         - video
         - podcast
@@ -146,6 +146,7 @@ components:
       required:
         - id
         - type
+        - kind
       properties:
         id:
           $ref: "#/components/schemas/cp_element_id"
@@ -265,7 +266,7 @@ components:
             kind:
               type: string
               enum:
-                - article
+                - standard
     CenterpageTeaserGallery:
       description: "A teaser module references/represents a gallery content object"
       allOf:
@@ -384,6 +385,10 @@ components:
               enum:
                 - region
               example: "region"
+            kind:
+              type: string
+              enum:
+                - standard
             items:
               type: array
               items:
@@ -397,6 +402,10 @@ components:
               enum:
                 - area
               example: "area"
+            kind:
+              type: string
+              enum:
+                - standard
             items:
               type: array
               items:

--- a/api.yaml
+++ b/api.yaml
@@ -267,6 +267,7 @@ components:
               type: string
               enum:
                 - teaser
+              example: "teaser"
     CenterpageTeaserGallery:
       description: "A teaser module references/represents a gallery content object"
       allOf:
@@ -278,6 +279,7 @@ components:
               type: string
               enum:
                 - teaser-gallery
+              example: "teaser-gallery"
             gallery:
               type: object
               properties:
@@ -296,6 +298,7 @@ components:
               type: string
               enum:
                 - teaser-video
+              example: "teaser-video"
             video:
               type: object
               properties:
@@ -318,6 +321,7 @@ components:
               type: string
               enum:
                 - teaser-podcast
+              example: "teaser-podcast"
             audio:
               type: object
               properties:

--- a/api.yaml
+++ b/api.yaml
@@ -150,6 +150,10 @@ components:
           type: number
           nullable: true
           example: 1.3333
+        fill_color:
+          type: string
+          nullable: true
+          example: "8ed8a6"
 
     audio_connection:
       properties:

--- a/api.yaml
+++ b/api.yaml
@@ -331,7 +331,7 @@ components:
             kind:
               type: string
               enum:
-               - podcast
+                - podcast
             audio:
               type: object
               properties:

--- a/api.yaml
+++ b/api.yaml
@@ -129,18 +129,12 @@ components:
       enum:
         - region
         - area
-        - module
-      description: "Type of the cp element"
-
-    cp_element_kind:
-      type: string
-      enum:
-        - standard
-        - gallery
-        - video
-        - podcast
+        - teaser
+        - teaser-gallery
+        - teaser-video
+        - teaser-podcast
         - html
-      description: "Kind of the cp element"
+      description: "Type of the cp element"
 
     audio_connection:
       properties:
@@ -160,14 +154,11 @@ components:
       required:
         - id
         - type
-        - kind
       properties:
         id:
           $ref: "#/components/schemas/cp_element_id"
         type:
           $ref: "#/components/schemas/cp_element_type"
-        kind:
-          $ref: "#/components/schemas/cp_element_kind"
     CenterpageTeaserBase:
       description: "A teaser module references/represents a content object (article, video, etc.)"
       allOf:
@@ -179,11 +170,6 @@ components:
             - dateFirstPublished
             - dateLastPublishedSemantic
           properties:
-            type:
-              type: string
-              enum:
-                - module
-              example: "module"
             layout:
               type: string
               # @check https://vivi.zeit.de/repository/data/cp-layouts.xml
@@ -272,15 +258,15 @@ components:
                   # format: uri
                   description: "URL directly to the comment area of the article"
                   example: "https://www.zeit.de/my/article#comments"
-    CenterpageTeaserArticle:
+    CenterpageTeaser:
       description: "A teaser module references/represents an article content object"
       allOf:
         - $ref: "#/components/schemas/CenterpageTeaserBase"
           properties:
-            kind:
+            type:
               type: string
               enum:
-                - standard
+                - teaser
     CenterpageTeaserGallery:
       description: "A teaser module references/represents a gallery content object"
       allOf:
@@ -288,10 +274,10 @@ components:
         - required:
             - gallery
           properties:
-            kind:
+            type:
               type: string
               enum:
-                - gallery
+                - teaser-gallery
             gallery:
               type: object
               properties:
@@ -306,10 +292,10 @@ components:
         - required:
             - video
           properties:
-            kind:
+            type:
               type: string
               enum:
-                - video
+                - teaser-video
             video:
               type: object
               properties:
@@ -328,10 +314,10 @@ components:
         - required:
             - audio
           properties:
-            kind:
+            type:
               type: string
               enum:
-                - podcast
+                - teaser-podcast
             audio:
               type: object
               properties:
@@ -362,7 +348,7 @@ components:
               enum:
                 - module
               example: "module"
-            kind:
+            type:
               type: string
               enum:
                 - html
@@ -428,7 +414,7 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: "#/components/schemas/CenterpageTeaserArticle"
+                  - $ref: "#/components/schemas/CenterpageTeaser"
                   - $ref: "#/components/schemas/CenterpageTeaserGallery"
                   - $ref: "#/components/schemas/CenterpageTeaserVideo"
                   - $ref: "#/components/schemas/CenterpageTeaserPodcast"

--- a/api.yaml
+++ b/api.yaml
@@ -141,7 +141,7 @@ components:
           $ref: "#/components/schemas/cp_element_id"
         type:
           $ref: "#/components/schemas/cp_element_type"
-    CenterpageModuleTeaser:
+    CenterpageTeaserBase:
       description: "A teaser module references/represents a content object (article, video, etc.)"
       allOf:
         - $ref: "#/components/schemas/CenterpageElement"

--- a/api.yaml
+++ b/api.yaml
@@ -353,7 +353,7 @@ components:
                   type: array
                   items:
                     $ref: "#/components/schemas/audio_connection"
-    CenterpageModuleWeb:
+    CenterpageModuleHTML:
       description: "A non-native module that should be displayed via a web view"
       allOf:
         - $ref: "#/components/schemas/CenterpageElement"
@@ -431,7 +431,7 @@ components:
                   - $ref: "#/components/schemas/CenterpageTeaserGallery"
                   - $ref: "#/components/schemas/CenterpageTeaserVideo"
                   - $ref: "#/components/schemas/CenterpageTeaserPodcast"
-                  - $ref: "#/components/schemas/CenterpageModuleWeb"
+                  - $ref: "#/components/schemas/CenterpageModuleHTML"
 
 
     TabDefinitionBase:

--- a/api.yaml
+++ b/api.yaml
@@ -136,6 +136,21 @@ components:
         - html
       description: "Type of the cp element"
 
+    image:
+      type: object
+      properties:
+        base_url:
+          type: string
+          # format: uri
+          example: "https://img.zeit.de/2020-08/flightradar-4/cinema"
+        ratio:
+          type: number
+          example: 1.7778
+        mobile_ratio:
+          type: number
+          nullable: true
+          example: 1.3333
+
     audio_connection:
       properties:
         id:
@@ -199,18 +214,9 @@ components:
               # format: uri
               example: "https://www.zeit.de/my/article"
             image:
-              type: object
-              properties:
-                base_url:
-                  type: string
-                  # format: uri
-                  example: "https://img.zeit.de/2020-08/flightradar-4/cinema"
-                ratio:
-                  type: number
-                  example: 1.7778
-                mobile_ratio: # optional
-                  type: number
-                  example: 1.3333
+              $ref: "#/components/schemas/image"
+            author_image:
+              $ref: "#/components/schemas/image"
             dateFirstPublished:
               type: string
               format: date-time

--- a/api.yaml
+++ b/api.yaml
@@ -129,8 +129,7 @@ components:
       enum:
         - region
         - area
-        - teaser
-        - web
+        - module
       description: "Type of the cp element"
 
     CenterpageElement:
@@ -156,8 +155,8 @@ components:
             type:
               type: string
               enum:
-                - teaser
-              example: "teaser"
+                - module
+              example: "module"
             layout:
               type: string
               # @check https://vivi.zeit.de/repository/data/cp-layouts.xml
@@ -256,8 +255,8 @@ components:
             type:
               type: string
               enum:
-                - web
-              example: "web"
+                - module
+              example: "module"
             raw_content:
               type: string
               format: html


### PR DESCRIPTION
Open for discussion. 

Eine Art `kind` bräuchten die areas und vielleicht die regions ja auch. Aber ob man das alles in einem Topf will … ob es bei Teasern besser `context` oder `content_type` heißen sollte … 🤔 

~Im Moment ist `kind` noch nicht required. Das ist für die Teaser eigentlich verkehrt.~ Wenn es required wird, muss man es auch gleich auf region und area draufstreuseln …