### PR TITLE
ZAPPI Coding style 2.0 RFC

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -81,7 +81,7 @@ paths:
         - in: path
           name: uuid
           schema:
-            $ref: "#/components/schemas/Uuid"
+            $ref: "#/components/schemas/UUID"
           required: true
           description: "UUID from CMS that identifies a CenterPage content object"
 
@@ -97,7 +97,7 @@ paths:
                 type: object
                 properties:
                   id:
-                    $ref: "#/components/schemas/Uuid"
+                    $ref: "#/components/schemas/UUID"
                   url:
                     type: string
                     # format: uri  XXX only supported in openapi-3.1
@@ -113,18 +113,18 @@ paths:
 
 components:
   schemas:
-    Uuid:
+    UUID:
       type: string
       pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9/]+)$"
       description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
       example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
 
-    CpElementId:
+    CenterpageElementId:
       type: string
       pattern: "^id-[-a-f0-9]+$"
       description: "ID of the cp element"
 
-    CpElementType:
+    CenterpageElementType:
       type: string
       enum:
         - region
@@ -139,9 +139,9 @@ components:
         - type
       properties:
         id:
-          $ref: "#/components/schemas/CpElementId"
+          $ref: "#/components/schemas/CenterpageElementId"
         type:
-          $ref: "#/components/schemas/CpElementType"
+          $ref: "#/components/schemas/CenterpageElementType"
     CenterpageModuleTeaser:
       description: "A teaser module references/represents a content object (article, video, etc.)"
       allOf:
@@ -449,7 +449,7 @@ components:
                 - id
               properties:
                 id:
-                  $ref: "#/components/schemas/Uuid"
+                  $ref: "#/components/schemas/UUID"
     MenuEntryWeb:
       allOf:
         - $ref: "#/components/schemas/MenuEntryBase"

--- a/api.yaml
+++ b/api.yaml
@@ -136,7 +136,7 @@ components:
         - html
       description: "Type of the cp element"
 
-    image:
+    Image:
       type: object
       properties:
         base_url:
@@ -158,7 +158,7 @@ components:
           type: boolean
           example: false
 
-    audio_connection:
+    AudioConnection:
       properties:
         id:
           type: string
@@ -221,9 +221,9 @@ components:
               # format: uri
               example: "https://www.zeit.de/my/article"
             image:
-              $ref: "#/components/schemas/image"
+              $ref: "#/components/schemas/Image"
             author_image:
-              $ref: "#/components/schemas/image"
+              $ref: "#/components/schemas/Image"
             date_first_published:
               type: string
               format: date-time
@@ -352,7 +352,7 @@ components:
                 connections:
                   type: array
                   items:
-                    $ref: "#/components/schemas/audio_connection"
+                    $ref: "#/components/schemas/AudioConnection"
     CenterpageModuleHTML:
       description: "A non-native module that should be displayed via a web view"
       allOf:

--- a/api.yaml
+++ b/api.yaml
@@ -46,30 +46,30 @@ paths:
                         - $ref: "#/components/schemas/TabDefinitionMenuView"
                         - $ref: "#/components/schemas/TabDefinitionStoryView"
               example: {tabs: [
-                {id: start, title: Start, type: cpView, icon: iconHouse, subMenu: [
-                  {id: homepage, title: Aktuell, type: menuEntryWeb, url: "https://www.zeit.de/index"},
-                  {id: ressortPolitik, title: Politik, type: menuEntryNative, cpItem: {id: "{urn:uuid:b4d1e3b1-aac4-4a80-b820-e4093fe24a36}"} },
-                  {id: ressortGesellschaft, title: Gesellschaft, type: menuEntryNative, cpItem: {id: "{urn:uuid:c92ad9be-67e0-497d-beee-6c2e063352cc}"} },
-                  {id: ressortWirtschaft, title: Wirtschaft, type: menuEntryNative, cpItem: {id: "{urn:uuid:ea13ef02-74f3-4010-8cd7-777327fb881a}"} },
-                  {id: ressortWissen, title: Wissen, type: menuEntryNative, cpItem: {id: "{urn:uuid:c84692ca-b0c9-4772-8c6b-85e2abc446e1}"} },
-                  {id: ressortKultur, title: Kultur, type: menuEntryNative, cpItem: {id: "{urn:uuid:49b109f0-bbad-495e-8a88-ad91ec1ef8f9}"} }
+                {id: start, title: Start, type: view-cp, icon: house, sub_menu: [
+                  {id: homepage, title: Aktuell, type: menu-entry-web, url: "https://www.zeit.de/index"},
+                  {id: ressortPolitik, title: Politik, type: menu-entry-native, cp_item: {id: "{urn:uuid:b4d1e3b1-aac4-4a80-b820-e4093fe24a36}"} },
+                  {id: ressortGesellschaft, title: Gesellschaft, type: menu-entry-native, cp_item: {id: "{urn:uuid:c92ad9be-67e0-497d-beee-6c2e063352cc}"} },
+                  {id: ressortWirtschaft, title: Wirtschaft, type: menu-entry-native, cp_item: {id: "{urn:uuid:ea13ef02-74f3-4010-8cd7-777327fb881a}"} },
+                  {id: ressortWissen, title: Wissen, type: menu-entry-native, cp_item: {id: "{urn:uuid:c84692ca-b0c9-4772-8c6b-85e2abc446e1}"} },
+                  {id: ressortKultur, title: Kultur, type: menu-entry-native, cp_item: {id: "{urn:uuid:49b109f0-bbad-495e-8a88-ad91ec1ef8f9}"} }
                 ]},
-                {id: news, title: Schlagzeilen, type: cpView, icon: iconClock, subMenu: [
-                  {id: newsAll, title: "Alle Schlagzeilen", type: menuEntryNative, cpItem: {id: "{urn:uuid:08945d5e-483c-4e7b-9843-69a8f590ada9}"} },
-                  {id: newsMostImportant, title: "Die wichtigsten Nachrichten", type: menuEntryNative, cpItem: {id: "{urn:uuid:df60a52c-5f4d-4804-833d-ec31e24dbd43}"} },
-                  {id: newsAnalysisAndReports, title: "Analysen und Hintergründe", type: menuEntryNative, cpItem: {id: "{urn:uuid:d6913463-1804-466d-b6d0-34376ef21916}"} }
+                {id: news, title: Schlagzeilen, type: view-cp, icon: clock, sub_menu: [
+                  {id: newsAll, title: "Alle Schlagzeilen", type: menu-entry-native, cp_item: {id: "{urn:uuid:08945d5e-483c-4e7b-9843-69a8f590ada9}"} },
+                  {id: newsMostImportant, title: "Die wichtigsten Nachrichten", type: menu-entry-native, cp_item: {id: "{urn:uuid:df60a52c-5f4d-4804-833d-ec31e24dbd43}"} },
+                  {id: newsAnalysisAndReports, title: "Analysen und Hintergründe", type: menu-entry-native, cp_item: {id: "{urn:uuid:d6913463-1804-466d-b6d0-34376ef21916}"} }
                 ]},
-                {id: discover, title: Entdecken, type: storyView, icon: iconCompass},
-                {id: zplus, title: Mein Abo, type: cpView, icon: iconZPlus, subMenu: [
-                  {id: exclusive, title: "Exklusive Artikel", type: menuEntryNative, cpItem: {id: "{urn:uuid:0fd9480f-1b52-4fcb-942e-8089e378102e}"} },
-                  {id: zeitPDFWebReader, title: "DIE ZEIT", type: menuEntryWeb, url: "https://epaper.zeit.de/abo/diezeit" },
-                  {id: wochenMarkt, title: "Wochenmarkt", type: menuEntryWeb, url: "https://www.zeit.de/wochenmarkt" }
+                {id: discover, title: Entdecken, type: view-story, icon: compass},
+                {id: zplus, title: Mein Abo, type: view-cp, icon: zplus, sub_menu: [
+                  {id: exclusive, title: "Exklusive Artikel", type: menu-entry-native, cp_item: {id: "{urn:uuid:0fd9480f-1b52-4fcb-942e-8089e378102e}"} },
+                  {id: zeitPDFWebReader, title: "DIE ZEIT", type: menu-entry-web, url: "https://epaper.zeit.de/abo/diezeit" },
+                  {id: wochenMarkt, title: "Wochenmarkt", type: menu-entry-web, url: "https://www.zeit.de/wochenmarkt" }
                 ]},
-                {id: menu, title: Mehr, type: menuView, icon: iconAvatar, sections: [
+                {id: menu, title: Mehr, type: view-menu, icon: avatar, sections: [
                   {id: user-menu, title: "Mein Bereich", entries: [
-                    {id: reading-list, title: Merkliste, type: menuEntryNative, targetId: native-reading-list},
-                    {id: reading-history, title: Verlauf, type: menuEntryNative, targetId: native-reading-history},
-                    {id: comment-list, title: Kommentare, type: menuEntryWeb, url: "https://profile.zeit.de"}
+                    {id: reading-list, title: Merkliste, type: menu-entry-native, target_id: native-reading-list},
+                    {id: reading-history, title: Verlauf, type: menu-entry-native, target_id: native-reading-history},
+                    {id: comment-list, title: Kommentare, type: menu-entry-web, url: "https://profile.zeit.de"}
                   ]}
                 ]}
               ]}

--- a/api.yaml
+++ b/api.yaml
@@ -150,8 +150,8 @@ components:
             - layout
             - title
             - url
-            - dateFirstPublished
-            - dateLastPublishedSemantic
+            - date_first_published
+            - date_last_published_semantic
           properties:
             type:
               type: string
@@ -199,12 +199,12 @@ components:
                 mobile_ratio: # optional
                   type: number
                   example: 1.3333
-            dateFirstPublished:
+            date_first_published:
               type: string
               format: date-time
               description: "Timestamp when the article was published initially"
               example: "2019-12-31T13:12:00Z"
-            dateLastPublishedSemantic:
+            date_last_published_semantic:
               type: string
               format: date-time
               description: "Timestamp of the most recent semantic/relevant update to the article"
@@ -346,14 +346,14 @@ components:
       allOf:
         - $ref: "#/components/schemas/TabDefinitionBase"
         - required:
-            - subMenu
+            - sub_menu
           properties:
             type:
               type: string
               enum:
                 - cpView
               example: "cpView"
-            subMenu:
+            sub_menu:
               type: array
               items:
                 oneOf:
@@ -372,7 +372,7 @@ components:
               # format: uri
               type: string
               example: "https://www.zeit.de/index"
-            subMenu:
+            sub_menu:
               type: array
               items:
                 oneOf:
@@ -436,7 +436,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/MenuEntryBase"
         - properties:
-            targetId:
+            target_id:
               type: string
               example: "some-native-id"
             type:
@@ -444,7 +444,7 @@ components:
               enum:
                 - menuEntryNative
               example: "menuEntryNative"
-            cpItem:
+            cp_item:
               required:
                 - id
               properties:

--- a/api.yaml
+++ b/api.yaml
@@ -335,13 +335,13 @@ components:
         type:
           type: string
           enum:
-            - cpView
-            - webView
-            - menuView
-            - storyView
+            - view-cp
+            - view-web
+            - view-menu
+            - view-story
         icon:
           type: string
-          example: iconHome
+          example: home
     TabDefinitionCpView:
       allOf:
         - $ref: "#/components/schemas/TabDefinitionBase"
@@ -351,8 +351,8 @@ components:
             type:
               type: string
               enum:
-                - cpView
-              example: "cpView"
+                - view-cp
+              example: "view-cp"
             sub_menu:
               type: array
               items:
@@ -366,8 +366,8 @@ components:
             type:
               type: string
               enum:
-                - webView
-              example: "webView"
+                - view-web
+              example: "view-web"
             url:
               # format: uri
               type: string
@@ -385,8 +385,8 @@ components:
             type:
               type: string
               enum:
-                - menuView
-              example: "menuView"
+                - view-menu
+              example: "view-menu"
             sections:
               type: array
               items:
@@ -398,8 +398,8 @@ components:
         type:
           type: string
           enum:
-            - storyView
-          example: "storyView"
+            - view-story
+          example: "view-story"
 
 
     MenuSection:
@@ -429,9 +429,9 @@ components:
         type:
           type: string
           enum:
-            - menuEntryNative
-            - menuEntryWeb
-            - menuEntryBrowser
+            - menu-entry-native
+            - menu-entry-web
+            - menu-entry-browser
     MenuEntryNative:
       allOf:
         - $ref: "#/components/schemas/MenuEntryBase"
@@ -442,8 +442,8 @@ components:
             type:
               type: string
               enum:
-                - menuEntryNative
-              example: "menuEntryNative"
+                - menu-entry-native
+              example: "menu-entry-native"
             cp_item:
               required:
                 - id
@@ -463,8 +463,8 @@ components:
             type:
               type: string
               enum:
-                - menuEntryWeb
-              example: "menuEntryWeb"
+                - menu-entry-web
+              example: "menu-entry-web"
     MenuEntryBrowser:
       allOf:
         - $ref: "#/components/schemas/MenuEntryBase"
@@ -477,8 +477,8 @@ components:
             type:
               type: string
               enum:
-                - menuEntryBrowser
-              example: "menuEntryBrowser"
+                - menu-entry-browser
+              example: "menu-entry-browser"
 
 
   securitySchemes:

--- a/api.yaml
+++ b/api.yaml
@@ -81,7 +81,7 @@ paths:
         - in: path
           name: uuid
           schema:
-            $ref: "#/components/schemas/uuid"
+            $ref: "#/components/schemas/Uuid"
           required: true
           description: "UUID from CMS that identifies a CenterPage content object"
 
@@ -97,7 +97,7 @@ paths:
                 type: object
                 properties:
                   id:
-                    $ref: "#/components/schemas/uuid"
+                    $ref: "#/components/schemas/Uuid"
                   url:
                     type: string
                     # format: uri  XXX only supported in openapi-3.1
@@ -113,18 +113,18 @@ paths:
 
 components:
   schemas:
-    uuid:
+    Uuid:
       type: string
       pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9/]+)$"
       description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
       example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
 
-    cp_element_id:
+    CpElementId:
       type: string
       pattern: "^id-[-a-f0-9]+$"
       description: "ID of the cp element"
 
-    cp_element_type:
+    CpElementType:
       type: string
       enum:
         - region
@@ -139,9 +139,9 @@ components:
         - type
       properties:
         id:
-          $ref: "#/components/schemas/cp_element_id"
+          $ref: "#/components/schemas/CpElementId"
         type:
-          $ref: "#/components/schemas/cp_element_type"
+          $ref: "#/components/schemas/CpElementType"
     CenterpageModuleTeaser:
       description: "A teaser module references/represents a content object (article, video, etc.)"
       allOf:
@@ -449,7 +449,7 @@ components:
                 - id
               properties:
                 id:
-                  $ref: "#/components/schemas/uuid"
+                  $ref: "#/components/schemas/Uuid"
     MenuEntryWeb:
       allOf:
         - $ref: "#/components/schemas/MenuEntryBase"

--- a/codingstyle.rst
+++ b/codingstyle.rst
@@ -18,6 +18,7 @@ Namen
 
 * Schema-Objekte verwenden CamelCase mit Großbuchstaben vorn
   (z.B. ``CenterpageElement``, ``TabDefinitionBase``)
-* Properties verwenden Snake-Case und werden klein geschrieben
+* Properties verwenden snake_case und werden klein geschrieben
   (z.B. ``base_url``, ``date_first_published``)
-  XXX mit Prepublic absprechen
+* Identifier verwenden kebab-case und werden klein geschrieben
+  (z.B. ``zplus-register``, ``menu-entry-native``)


### PR DESCRIPTION
# YAML Coding-Style

## Syntax

* Indentation: 2 Leerzeichen
  (Listen immer einrücken, auch wenn der yaml-Standard es dort nicht zwingend verlangt)
* Strings quoten mit Double Quotes (``"foobar"``, NICHT ``'foobar'``)
* Identifier nicht quoten (``type: string``, NICHT ``type: "string"``)
* Leerzeilen zwischen inhaltlichen Abschnitten verwenden
* Inline Listen/Dicts höchstens bei Beispielen verwenden (z.B. ``example: ["zplus"]``), sonst immer neue Zeile und einrücken

## Namen

* Schema-Objekte verwenden CamelCase mit Großbuchstaben vorn
  (z.B. ``CenterpageElement``, ``TabDefinitionBase``)
* Properties verwenden snake_case und werden klein geschrieben
  (z.B. ``base_url``, ``date_first_published``)
* Identifier verwenden kebab-case und werden klein geschrieben
  (z.B. ``zplus-register``, ``menu-entry-native``)
