### PR TITLE
MAINT: Adapt TabBase to current example structure

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -442,7 +442,6 @@ components:
         - title
         - type
         - icon
-        - items
       properties:
         id:
           type: string
@@ -462,12 +461,12 @@ components:
         icon:
           type: string
           example: home
-        items:
-          type: array
     TabCenterpage:
       allOf:
         - $ref: "#/components/schemas/TabBase"
-        - properties:
+        - required:
+            - items
+          properties:
             type:
               type: string
               enum:
@@ -482,7 +481,9 @@ components:
     TabMenu:
       allOf:
         - $ref: "#/components/schemas/TabBase"
-        - properties:
+        - required:
+            - items
+          properties:
             type:
               type: string
               enum:
@@ -495,7 +496,9 @@ components:
     TabStory:
       allOf:
         - $ref: "#/components/schemas/TabBase"
-        - properties:
+        - required:
+            - source
+          properties:
             type:
               type: string
               enum:


### PR DESCRIPTION
Wir sind uns noch nicht ganz sicher, wie der _"Single-Page"_ Tab `Entdecken` strukturiert sein soll, im Unterschied zu den anderen _"Multi-Page with submenu"_ Tabs. Entweder er referenziert direkt die Quelle wie hier beschrieben, oder wir erfinden ein Regelwerk, das `items` auch nur 1 item enthalten kann und dann ohne Submenü dargestellt wird.