### PR TITLE
MAINT: Use link label for comments

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -265,9 +265,10 @@ components:
             comments:
               type: object
               properties:
-                count:
-                  type: integer
-                  description: "Current count of comments for this article"
+                label:
+                  type: string
+                  description: "Descriptive label for count of comments for this article"
+                  example: "18 Kommentare"
                 url:
                   type: string
                   # format: uri


### PR DESCRIPTION
Laut Konzept wollen wir bevorzugt die _fertigen_ Infos in die Apps geben. Das wäre für den Link zu den Kommentaren der Link-Text, nicht die Anzahl der Kommentare als Integer. Analog zu den Galerien.