### PR TITLE
MAINT: Update teaser layouts and badges

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -198,11 +198,13 @@ components:
               type: string
               # @check https://vivi.zeit.de/repository/data/cp-layouts.xml
               enum:
+                - zon-teaser-list
+                - zon-teaser-printbox
+                - zon-teaser-small
+                - zon-teaser-square
+                - zon-teaser-square-author
                 - zon-teaser-standard
                 - zon-teaser-wide
-                - zon-teaser-square-author
-                - zon-teaser-poster
-                # news-teaser
               description: "How to display this teaser (e.g large/small)"
             title:
               type: string

--- a/api.yaml
+++ b/api.yaml
@@ -140,7 +140,6 @@ components:
 
     Image:
       type: object
-      nullable: true
       properties:
         baseUrl:
           type: string
@@ -228,9 +227,13 @@ components:
               # format: uri
               example: "https://www.zeit.de/my/article"
             image:
-              $ref: "#/components/schemas/Image"
+              allOf:
+                - $ref: "#/components/schemas/Image"
+                - nullable: true
             authorImage:
-              $ref: "#/components/schemas/Image"
+              allOf:
+                - $ref: "#/components/schemas/Image"
+                - nullable: true
             dateFirstPublished:
               type: string
               format: date-time

--- a/api.yaml
+++ b/api.yaml
@@ -140,6 +140,7 @@ components:
 
     Image:
       type: object
+      nullable: true
       properties:
         baseUrl:
           type: string

--- a/api.yaml
+++ b/api.yaml
@@ -247,15 +247,15 @@ components:
               type: array
               items:
                 type: string
-                # ZON-6127: disabled until the implementation catches up:
-                # enum:
-                #   - brandeins
-                #   - liveblog
-                #   - liveblog-closed
-                #   - zett
-                #   - zplus
-                #   - zplus-register
-                #   - zplus-spiele
+                enum:
+                  - brandeins
+                  - liveblog
+                  - liveblog-closed
+                  - zett
+                  - zplus
+                  - zplus-register
+                  - zplus-dynamic
+                  - zplus-spiele
               description: "List of icon IDs that should be displayed for this teaser"
               example: ["zplus"]
             label:

--- a/api.yaml
+++ b/api.yaml
@@ -202,9 +202,11 @@ components:
                 - zon-teaser-list
                 - zon-teaser-printbox
                 - zon-teaser-small
+                - zon-teaser-small-compact
                 - zon-teaser-square
-                - zon-teaser-square-author
+                - zon-teaser-square-compact
                 - zon-teaser-standard
+                - zon-teaser-standard-compact
                 - zon-teaser-wide
               description: "How to display this teaser (e.g large/small)"
             title:
@@ -431,6 +433,7 @@ components:
             layout:
               type: string
               enum:
+                - tab
                 - headed
                 - standard
             items:

--- a/api.yaml
+++ b/api.yaml
@@ -431,6 +431,7 @@ components:
             layout:
               type: string
               enum:
+                - headed
                 - standard
             items:
               type: array


### PR DESCRIPTION
Mit ZeitOnline/zeit.web#4193 sollten nur noch bekannte teaser layouts und badges ausgegeben werden.

![](https://media.giphy.com/media/hV04hesI73vJDLqfbR/giphy.gif)