### PR TITLE
ZON-6134: Enable teaser modules at top level

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -185,6 +185,7 @@ components:
           example: false
 
     AudioConnection:
+      type: object
       properties:
         id:
           type: string

--- a/api.yaml
+++ b/api.yaml
@@ -46,7 +46,13 @@ paths:
                 items:
                   type: array
                   items:
-                    $ref: "#/components/schemas/CenterpageRegion"
+                    oneOf:
+                      - $ref: "#/components/schemas/CenterpageTeaser"
+                      - $ref: "#/components/schemas/CenterpageTeaserGallery"
+                      - $ref: "#/components/schemas/CenterpageTeaserVideo"
+                      - $ref: "#/components/schemas/CenterpageTeaserPodcast"
+                      - $ref: "#/components/schemas/CenterpageModuleHTML"
+
   /structure:
     get:
       tags:
@@ -99,7 +105,6 @@ paths:
                 ]}
               ]}
 
-
   /cp/{uuid}:
     get:
       parameters:
@@ -119,19 +124,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    $ref: "#/components/schemas/UUID"
-                  url:
-                    type: string
-                    # format: uri  XXX only supported in openapi-3.1
-                    description: "Web URL for this CenterPage"
-                    example: "https://www.zeit.de/politik/index"
-                  items:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/CenterpageRegion"
+                $ref: "#/components/schemas/Centerpage"
         "404":
           description: "No centerpage found for the given uuid"
 
@@ -143,6 +136,28 @@ components:
       pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9/]+)$"
       description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
       example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
+
+    Centerpage:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/UUID"
+        url:
+          type: string
+          # format: uri  XXX only supported in openapi-3.1
+          description: "Web URL for this CenterPage"
+          example: "https://www.zeit.de/politik/index"
+        items:
+          type: array
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/CenterpageRegion"
+              - $ref: "#/components/schemas/CenterpageArea"
+              - $ref: "#/components/schemas/CenterpageTeaser"
+              - $ref: "#/components/schemas/CenterpageTeaserGallery"
+              - $ref: "#/components/schemas/CenterpageTeaserVideo"
+              - $ref: "#/components/schemas/CenterpageTeaserPodcast"
+              - $ref: "#/components/schemas/CenterpageModuleHTML"
 
     CenterpageElementId:
       type: string

--- a/api.yaml
+++ b/api.yaml
@@ -439,7 +439,9 @@ components:
             layout:
               type: string
               enum:
+                - duo
                 - standard
+                - tablist
             items:
               type: array
               items:
@@ -456,9 +458,12 @@ components:
             layout:
               type: string
               enum:
-                - tab
+                - duo
                 - headed
+                - headed-light
                 - standard
+                - tab
+                - tabpanel
             items:
               type: array
               items:

--- a/api.yaml
+++ b/api.yaml
@@ -148,6 +148,7 @@ components:
       type: string
       pattern: "^id-[-a-f0-9]+$"
       description: "ID of the cp element"
+      example: "id-fcfd3deb-4c26-472b-8bdd-238372d5131b"
 
     CenterpageElementType:
       type: string


### PR DESCRIPTION
Prepublic wollen Teaser auf der obersten Ebene, wenn es keinen Sinn ergibt, sie in einen Container zu stecken. Zusätzlich werden ein paar neue Layouts hinzugefügt.

![](https://media.giphy.com/media/z5NV9mn7afmM0/giphy.gif)