### PR TITLE
ZON-6178: add bookmarks endpoint for API

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -25,13 +25,6 @@ servers:
 paths:
   /bookmarks:
     get:
-      # parameters:
-      #   - in: header
-      #     name: ssoid
-      #     required: true
-      #     description: string ID of sso cookie to identify user
-      #     schema:
-      #       $ref: "#/components/schemas/SSOID"
       summary: "Returns the list of bookmarks"
       tags:
         - bookmarks
@@ -160,10 +153,6 @@ components:
       pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9/]+)$"
       description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
       example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
-
-    SSOID:
-      type: string
-      description: "Users SSOID equal to value of users sso-cookie value."
 
     Centerpage:
       type: object
@@ -561,7 +550,6 @@ components:
               type: string
               enum:
                 - bookmarks
-                - history
             items:
               type: array
               items:

--- a/api.yaml
+++ b/api.yaml
@@ -546,14 +546,15 @@ components:
                   - $ref: "#/components/schemas/CenterpageTeaserPodcast"
                   - $ref: "#/components/schemas/CenterpageModuleHTML"
     ReadingList:
-      - properties:
-          type:
-            type: string
-            enum:
-              - bookmarks
-              - history
-          items:
-            type: array
+      allOf:
+        - properties:
+            type:
+              type: string
+              enum:
+                - bookmarks
+                - history
+            items:
+              type: array
 
 
     TabBase:

--- a/api.yaml
+++ b/api.yaml
@@ -23,6 +23,29 @@ servers:
           - "0.3.1"
 
 paths:
+  /bookmarks/{ssoid}:
+    get:
+      parameters:
+        - in: path
+          name: ssoid
+          required: true
+          description: string ID of sso cookie to identify user
+          schema:
+            type: string
+            # $ref: "#/components/schemas/SSOID"
+      summary: "Returns the list of bookmarks"
+      tags:
+        - bookmarks
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadingList"
+          description: "Success"
+
+        "404":
+          description: "Page not found"
   /search:
    get:
     tags:
@@ -138,7 +161,7 @@ components:
 
     SSOID:
       type: string
-      description: "Users SSOID "
+      description: "Users SSOID equal to value of users sso-cookie value."
 
     Centerpage:
       type: object
@@ -522,6 +545,15 @@ components:
                   - $ref: "#/components/schemas/CenterpageTeaserVideo"
                   - $ref: "#/components/schemas/CenterpageTeaserPodcast"
                   - $ref: "#/components/schemas/CenterpageModuleHTML"
+    ReadingList:
+      - properties:
+          type:
+            type: string
+            enum:
+              - bookmarks
+              - history
+          items:
+            type: array
 
 
     TabBase:

--- a/api.yaml
+++ b/api.yaml
@@ -131,32 +131,6 @@ paths:
         "404":
           description: "No centerpage found for the given uuid"
 
-  /merkliste:
-    get:
-      parameters:
-        - in: ssoid
-          required: true
-          description: "SSOID from SSO to identify the user's bookmarks"
-    tags:
-      - merkliste
-    summary: "Returns the list of bookmarks"
-    responses:
-      "200":
-        description: "Success"
-          content:
-            application/json:
-              schema:
-                url:
-                  type: string
-                  description: "https://www.zeit.de/konto/listen/merkliste"
-                items:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/CenterpageRegion"
-      "404":
-        description: "No list of bookmarks found for the given user."
-
-
 components:
   schemas:
     UUID:
@@ -164,6 +138,10 @@ components:
       pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9/]+)$"
       description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
       example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
+
+    SSOID:
+      type: string
+      description: "Users SSOID "
 
     Centerpage:
       type: object
@@ -712,7 +690,6 @@ components:
               enum:
                 - menu-item-browser
               example: "menu-item-browser"
-
 
   securitySchemes:
     default:

--- a/api.yaml
+++ b/api.yaml
@@ -23,10 +23,10 @@ servers:
           - "0.3.1"
 
 paths:
-  /bookmarks/{ssoid}:
+  /bookmarks:
     get:
       parameters:
-        - in: path
+        - in: header
           name: ssoid
           required: true
           description: string ID of sso cookie to identify user
@@ -45,6 +45,30 @@ paths:
 
         "404":
           description: "Page not found"
+
+  /cp/{uuid}:
+    get:
+      parameters:
+        - in: path
+          name: uuid
+          schema:
+            $ref: "#/components/schemas/UUID"
+          required: true
+          description: "UUID from CMS that identifies a CenterPage content object"
+
+      tags:
+        - cp
+      summary: "Returns the teasers (i.e. content references) on a CenterPage"
+      responses:
+        "200":
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Centerpage"
+        "404":
+          description: "No centerpage found for the given uuid"
+
   /search:
    get:
     tags:
@@ -126,29 +150,6 @@ paths:
                   ]}
                 ]}
               ]}
-
-  /cp/{uuid}:
-    get:
-      parameters:
-        - in: path
-          name: uuid
-          schema:
-            $ref: "#/components/schemas/UUID"
-          required: true
-          description: "UUID from CMS that identifies a CenterPage content object"
-
-      tags:
-        - cp
-      summary: "Returns the teasers (i.e. content references) on a CenterPage"
-      responses:
-        "200":
-          description: "Success"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Centerpage"
-        "404":
-          description: "No centerpage found for the given uuid"
 
 components:
   schemas:

--- a/api.yaml
+++ b/api.yaml
@@ -479,7 +479,7 @@ components:
         - $ref: "#/components/schemas/CenterpageElement"
         - required:
             - layout
-            eq  seds- link
+            - link
             - title
             - items
           properties:

--- a/api.yaml
+++ b/api.yaml
@@ -553,7 +553,8 @@ components:
               example: "type: bookmarks"
             items:
               type: array
-              items:
+              items: 
+                # ZON-6178: to be specified, when content objects layouts without teasers are solved
                 type: object
               example: 
                 "a list of elements like CenterpageTeaser, CenterpageTeaserGallery, etc."

--- a/api.yaml
+++ b/api.yaml
@@ -555,7 +555,8 @@ components:
               type: array
               items:
                 type: object
-              example: "a list of elements like CenterpageTeaser, CenterpageTeaserGallery, etc."
+              example: 
+                "a list of elements like CenterpageTeaser, CenterpageTeaserGallery, etc."
 
 
     TabBase:

--- a/api.yaml
+++ b/api.yaml
@@ -31,8 +31,7 @@ paths:
           required: true
           description: string ID of sso cookie to identify user
           schema:
-            type: string
-            # $ref: "#/components/schemas/SSOID"
+            $ref: "#/components/schemas/SSOID"
       summary: "Returns the list of bookmarks"
       tags:
         - bookmarks

--- a/api.yaml
+++ b/api.yaml
@@ -25,13 +25,13 @@ servers:
 paths:
   /bookmarks:
     get:
-      parameters:
-        - in: header
-          name: ssoid
-          required: true
-          description: string ID of sso cookie to identify user
-          schema:
-            $ref: "#/components/schemas/SSOID"
+      # parameters:
+      #   - in: header
+      #     name: ssoid
+      #     required: true
+      #     description: string ID of sso cookie to identify user
+      #     schema:
+      #       $ref: "#/components/schemas/SSOID"
       summary: "Returns the list of bookmarks"
       tags:
         - bookmarks
@@ -564,6 +564,8 @@ components:
                 - history
             items:
               type: array
+              items:
+                type: object
 
 
     TabBase:

--- a/api.yaml
+++ b/api.yaml
@@ -479,7 +479,7 @@ components:
         - $ref: "#/components/schemas/CenterpageElement"
         - required:
             - layout
-            - link
+            eq  seds- link
             - title
             - items
           properties:
@@ -550,10 +550,12 @@ components:
               type: string
               enum:
                 - bookmarks
+              example: "type: bookmarks"
             items:
               type: array
               items:
                 type: object
+              example: "a list of elements like CenterpageTeaser, CenterpageTeaserGallery, etc."
 
 
     TabBase:

--- a/api.yaml
+++ b/api.yaml
@@ -112,6 +112,31 @@ paths:
         "404":
           description: "No centerpage found for the given uuid"
 
+  /merkliste:
+    get:
+      parameters:
+        - in: ssoid
+          required: true
+          description: "SSOID from SSO to identify the user's bookmarks"
+    tags:
+      - merkliste
+    summary: "Returns the list of bookmarks"
+    responses:
+      "200":
+        description: "Success"
+          content:
+            application/json:
+              schema:
+                url:
+                  type: string
+                  description: "https://www.zeit.de/konto/listen/merkliste"
+                items:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/CenterpageRegion"
+      "404":
+        description: "No list of bookmarks found for the given user."
+
 
 components:
   schemas:

--- a/api.yaml
+++ b/api.yaml
@@ -249,6 +249,13 @@ components:
         visibleMobile:
           type: boolean
           example: false
+        variant:
+          type: string
+          example: "standard"
+        mobileVariant:
+          type: string
+          nullable: true
+          example: "standard"
 
     AudioConnection:
       type: object


### PR DESCRIPTION
### Was erledigt dieser PR?

fügt einen Merklisten Endpunkt zur API hinzu. Momentan kann dieser noch nicht genutzt werden, da die Authentifizierung noch aussteht. Zudem ist nicht sicher, ob die SSOID im Pfad mitgegeben wird. 

### Wo geht's los?

`docs-zappi/api.yaml`

### Wie kann getestet werden?
Lokal `$ bin/serve`

### Relevante Tickets

https://zeit-online.atlassian.net/browse/ZON-6178

### Todos

- [ ] Authentifizierung klären und einbauen

### Gif

![bye](https://media.giphy.com/media/tUQqF6Ct1u7EQ/giphy.gif)