### PR TITLE
ZON-6179: specify openapi's error message

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -52,6 +52,8 @@ paths:
                       - $ref: "#/components/schemas/CenterpageTeaserVideo"
                       - $ref: "#/components/schemas/CenterpageTeaserPodcast"
                       - $ref: "#/components/schemas/CenterpageModuleHTML"
+      "400":
+        description: "Invalid query, see response body for details."
 
   /structure:
     get:


### PR DESCRIPTION
otherwise the validation itself is suppressed as an "unknown response".
this enables the helpful error messages from pyramid_openapi