### PR TITLE
ZON-6248: add Advertisement attribute to api

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -406,7 +406,9 @@ components:
                 id:
                   type: string
                   example: "6194436097001"
-                  hasAdvertisement: bool
+                hasAdvertisement: 
+                  type: bool
+                  example: "true/false"
                 # provider: "brightcove"
                 # product-id:
                 # page-url:

--- a/api.yaml
+++ b/api.yaml
@@ -408,7 +408,6 @@ components:
                   example: "6194436097001"
                 hasAdvertisement: 
                   type: boolean
-                  example: "true/false"
                 # provider: "brightcove"
                 # product-id:
                 # page-url:

--- a/api.yaml
+++ b/api.yaml
@@ -406,7 +406,7 @@ components:
                 id:
                   type: string
                   example: "6194436097001"
-                # advertising: bool
+                  hasAdvertisement: bool
                 # provider: "brightcove"
                 # product-id:
                 # page-url:

--- a/api.yaml
+++ b/api.yaml
@@ -407,7 +407,7 @@ components:
                   type: string
                   example: "6194436097001"
                 hasAdvertisement: 
-                  type: bool
+                  type: boolean
                   example: "true/false"
                 # provider: "brightcove"
                 # product-id:


### PR DESCRIPTION
### Was erledigt dieser PR?
Fügt einen dem CenterpageVideoTeaser ein hasAdvertisement Attribut hinzu

### Wo geht's los?
docs-zappi/api.yaml
zeit.web/app/centerpage.py

### Wie kann getestet werden?
im friedbert-deployment
$ bin/test zeit.web/src/zeit/web/app/test/test_centerpage.py

### Relevante Tickets
https://zeit-online.atlassian.net/browse/ZON-6248
