### PR TITLE
ZON-6179: make id optional

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -265,7 +265,6 @@ components:
 
     CenterpageElement:
       required:
-        - id
         - type
       properties:
         id:


### PR DESCRIPTION
it doesn't make sense for search results (or we could shoehorn the uuid
into it) but we don't actually need an id here so the easy solution is
to simply make it optional.

this change will then allow search results to use the existing
centerpage adapters and their content should "just work"