### PR TITLE
ZON-6178: bookmarks security schema

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -543,21 +543,6 @@ components:
                   - $ref: "#/components/schemas/CenterpageTeaserVideo"
                   - $ref: "#/components/schemas/CenterpageTeaserPodcast"
                   - $ref: "#/components/schemas/CenterpageModuleHTML"
-    ReadingList:
-      allOf:
-        - properties:
-            type:
-              type: string
-              enum:
-                - bookmarks
-              example: "type: bookmarks"
-            items:
-              type: array
-              items: 
-                # ZON-6178: to be specified, when content objects layouts without teasers are solved
-                type: object
-              example: 
-                "a list of elements like CenterpageTeaser, CenterpageTeaserGallery, etc."
 
 
     TabBase:

--- a/api.yaml
+++ b/api.yaml
@@ -25,6 +25,8 @@ servers:
 paths:
   /bookmarks:
     get:
+      security:
+        - cookieAuth: []
       summary: "Returns the list of bookmarks"
       tags:
         - bookmarks
@@ -712,3 +714,7 @@ components:
     default:
       type: http
       scheme: basic
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: zeit_sso_201501

--- a/api.yaml
+++ b/api.yaml
@@ -33,7 +33,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ReadingList"
+                $ref: "#/components/schemas/Centerpage"
           description: "Success"
 
         "404":


### PR DESCRIPTION
### Was erledigt dieser PR?

1. Fügt Authentifizierung mit einem SSO Cookie für den bookmarks API-Endpunkt hinzu. Die Authentifizierung ist absichtlich nicht auf root-Level eingebaut, um keine weiteren Komponenten der API zu beeinträchtigen. 
2. Das ReadingList Schema wurde entfernt. Die API liefert nun ein Teaser-Layout für Bookmark-Items aus, daher kann einfach das Centerpage-Schema genutzt werden. 

### Wo geht's los?

`api.yaml`

### Wie kann getestet werden?
in zeit.web
`bin/test zeit.web/src/zeit/web/app/test/test_view_bookmarks`

### Relevante Tickets

https://zeit-online.atlassian.net/browse/ZON-6178

### Todos

diese Authentifizierung ist für MVP-Zwecke gedacht und sollte zügig durch die gewünschte OpenID Connect Authentifizierung ersetzt werden.

### Gif

![got a ticket](https://media.giphy.com/media/vDZibnnI0saJi/giphy.gif)