### PR TITLE
ZON-6268 teaser UUID

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -328,6 +328,10 @@ components:
               type: string
               # format: uri
               example: "https://www.zeit.de/my/article"
+            uuid:
+              type: string
+              description: "The uuid of the content object including the `{urn:uuid:}` prefix"
+              example: "{urn:uuid:26024919-417f-4952-8801-70220d489078}"
             image:
               $ref: "#/components/schemas/Image"
             authorImage:

--- a/api.yaml
+++ b/api.yaml
@@ -438,7 +438,7 @@ components:
                 id:
                   type: string
                   example: "6194436097001"
-                hasAdvertisement: 
+                hasAdvertisement:
                   type: boolean
                 # provider: "brightcove"
                 # product-id:


### PR DESCRIPTION
Fuer Teaser wird jetzt auch die UUID des geteaseden Objektes ausgeliefert, damit sie direkt gebookmarked werden koennen