### PR TITLE
ZON-6263: Post and delete bookmark entries

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -47,17 +47,26 @@ paths:
         - cookieAuth: []
       parameters:
         - in: path
+          name: uuid
           required: true
           schema:
             $ref: "#/components/schemas/UUID"
-    put:
+      responses:
+        "200":
+          description: "Saved bookmark to bookmarkslist"
+
+    delete:
       security:
         - cookieAuth: []
       parameters:
         - in: path
+          name: uuid
           required: true
           schema:
             $ref: "#/components/schemas/UUID"
+      responses:
+        "200":
+          description: "Deleted bookmark to bookmarkslist"
 
   /config/{filename}:
     get:

--- a/api.yaml
+++ b/api.yaml
@@ -40,13 +40,11 @@ paths:
 
         "404":
           description: "Page not found"
-
-  /bookmark/{uuid}:
     post:
       security:
         - cookieAuth: []
       parameters:
-        - in: path
+        - in: body
           name: uuid
           required: true
           schema:
@@ -54,7 +52,7 @@ paths:
       responses:
         "200":
           description: "Saved bookmark to bookmarkslist"
-
+  /bookmarks/{uuid}:
     delete:
       security:
         - cookieAuth: []

--- a/api.yaml
+++ b/api.yaml
@@ -39,6 +39,8 @@ paths:
         "404":
           description: "Page not found"
     post:
+      security:
+        - cookieAuth: []
       summary: Add a new bookmark
       requestBody:
         required: true

--- a/api.yaml
+++ b/api.yaml
@@ -37,18 +37,17 @@ paths:
               schema:
                 $ref: "#/components/schemas/Centerpage"
           description: "Success"
-
         "404":
           description: "Page not found"
     post:
-      security:
-        - cookieAuth: []
-      parameters:
-        - in: body
-          name: uuid
-          required: true
-          schema:
-            $ref: "#/components/schemas/UUID"
+      summary: Add a new bookmark
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Centerpage"
+
       responses:
         "200":
           description: "Saved bookmark to bookmarkslist"
@@ -201,6 +200,13 @@ paths:
 
 components:
   schemas:
+
+    BookmarkEntry:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/UUID"
+
     UUID:
       type: string
       pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9/]+)$"

--- a/api.yaml
+++ b/api.yaml
@@ -50,7 +50,9 @@ paths:
               $ref: "#/components/schemas/BookmarkEntry"
       responses:
         "200":
-          description: "Saved bookmark to bookmarkslist"
+          description: "Saved entry to bookmarks"
+        "404":
+          description: "Not found"
 
   /bookmarks/{uuid}:
     delete:
@@ -64,7 +66,9 @@ paths:
             $ref: "#/components/schemas/UUID"
       responses:
         "200":
-          description: "Deleted bookmark from bookmarkslist"
+          description: "Deleted entry from bookmarks"
+        "404":
+          description: "Not found"
 
   /config/{filename}:
     get:

--- a/api.yaml
+++ b/api.yaml
@@ -214,7 +214,7 @@ components:
 
     UUID:
       type: string
-      pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9]+)$"
+      pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9/]+)$"
       description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
       example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
 

--- a/api.yaml
+++ b/api.yaml
@@ -41,6 +41,24 @@ paths:
         "404":
           description: "Page not found"
 
+  /bookmark/{uuid}:
+    post:
+      security:
+        - cookieAuth: []
+      parameters:
+        - in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/UUID"
+    put:
+      security:
+        - cookieAuth: []
+      parameters:
+        - in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/UUID"
+
   /config/{filename}:
     get:
       parameters:

--- a/api.yaml
+++ b/api.yaml
@@ -36,8 +36,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/Centerpage"
           description: "Success"
-        "404":
-          description: "Page not found"
+        "400":
+          description: "Not found"
+        "401":
+          description: "Unauthorized"
     post:
       security:
         - cookieAuth: []
@@ -47,12 +49,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BookmarkEntry"
+              type: object
+              properties:
+                id:
+                  $ref:   "#/components/schemas/UUID"
       responses:
-        "200":
+        "204":
           description: "Saved entry to bookmarks"
-        "404":
-          description: "Not found"
+        "401":
+          description: "Unauthorized"
 
   /bookmarks/{uuid}:
     delete:
@@ -65,10 +70,10 @@ paths:
           schema:
             $ref: "#/components/schemas/UUID"
       responses:
-        "200":
+        "204":
           description: "Deleted entry from bookmarks"
-        "404":
-          description: "Not found"
+        "401":
+          description: "Unauthorized"
 
   /config/{filename}:
     get:
@@ -204,17 +209,12 @@ paths:
               ]}
 
 components:
-  schemas:
 
-    BookmarkEntry:
-      type: object
-      properties:
-        id:
-          $ref: "#/components/schemas/UUID"
+  schemas:
 
     UUID:
       type: string
-      pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9/]+)$"
+      pattern: "^(\\{urn:uuid:[-a-f0-9]+\\}|[-a-z0-9]+)$"
       description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
       example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
 

--- a/api.yaml
+++ b/api.yaml
@@ -46,11 +46,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Centerpage"
-
+              $ref: "#/components/schemas/BookmarkEntry"
       responses:
         "200":
           description: "Saved bookmark to bookmarkslist"
+
   /bookmarks/{uuid}:
     delete:
       security:

--- a/api.yaml
+++ b/api.yaml
@@ -62,7 +62,7 @@ paths:
             $ref: "#/components/schemas/UUID"
       responses:
         "200":
-          description: "Deleted bookmark to bookmarkslist"
+          description: "Deleted bookmark from bookmarkslist"
 
   /config/{filename}:
     get:


### PR DESCRIPTION
### Was erledigt dieser PR?
Stellt Endpunkte für das Hinzufügen und Entfernen von Einträgen der Merkliste bereit. Es muss ein sso_cookie mitgeschickt werden. 

### Wie kann getestet werden?
Nach dem Mergen des zeit.web PRs:
`bin/test zeit.web/src/zeit/web/app/test/test_view_bookmarks.py`

### Relevante Tickets
https://zeit-online.atlassian.net/browse/ZON-6263