### PR TITLE
ZON-6263: Post and delete bookmark entries in Zappi

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -60,6 +60,8 @@ paths:
           description: "Bad Request"
         "401":
           description: "Unauthorized"
+        "403":
+          description: "Forbidden"
         "502":
           description: "Bad gateway"
 
@@ -80,6 +82,8 @@ paths:
           description: "Bad Request"
         "401":
           description: "Unauthorized"
+        "403":
+          description: "Forbidden"
         "502":
           description: "Bad gateway"
 

--- a/api.yaml
+++ b/api.yaml
@@ -58,6 +58,8 @@ paths:
           description: "Saved entry to bookmarks"
         "401":
           description: "Unauthorized"
+        "502":
+          description: "Bad gateway"
 
   /bookmarks/{uuid}:
     delete:
@@ -74,6 +76,8 @@ paths:
           description: "Deleted entry from bookmarks"
         "401":
           description: "Unauthorized"
+        "502":
+          description: "Bad gateway"
 
   /config/{filename}:
     get:

--- a/api.yaml
+++ b/api.yaml
@@ -37,7 +37,7 @@ paths:
                 $ref: "#/components/schemas/Centerpage"
           description: "Success"
         "400":
-          description: "Not found"
+          description: "Bad Request"
         "401":
           description: "Unauthorized"
     post:
@@ -56,6 +56,8 @@ paths:
       responses:
         "204":
           description: "Saved entry to bookmarks"
+        "400":
+          description: "Bad Request"
         "401":
           description: "Unauthorized"
         "502":
@@ -74,6 +76,8 @@ paths:
       responses:
         "204":
           description: "Deleted entry from bookmarks"
+        "400":
+          description: "Bad Request"
         "401":
           description: "Unauthorized"
         "502":


### PR DESCRIPTION
### Was erledigt dieser PR?
Zappi kann Einträge zur Merkliste hinzufügen und entfernen und es gibt jetzt auch vernünftige error responses.

### Wie kann getestet werden?
in zeit.web:
`bin/test zeit.web/src/zeit/web/app/test/test_view_bookmarks.py`

### Relevante Tickets
https://zeit-online.atlassian.net/browse/ZON-6263
