### PR TITLE
ZON-6327: Metainfos on centerpage

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -283,7 +283,8 @@ components:
         pagetitle:
           type: string
         bookmarkable:
-          type: string
+          type: boolean
+          example: true
         items:
           type: array
           items:

--- a/api.yaml
+++ b/api.yaml
@@ -280,6 +280,10 @@ components:
           # format: uri  XXX only supported in openapi-3.1
           description: "Web URL for this CenterPage"
           example: "https://www.zeit.de/politik/index"
+        pagetitle:
+          type: string
+        bookmarkable:
+          type: string
         items:
           type: array
           items:


### PR DESCRIPTION
### Was erledigt dieser PR?

Centerpages liefern nun die Metainformationen für die History.

### Wo geht's los?

`api.yaml`

### Wie kann getestet werden?

in zeit.web `bin/test zeit.web/src/zeit/web/app/test/test_view_centerpage.py`

### Relevante Tickets

https://zeit-online.atlassian.net/browse/ZON-6327
