### PR TITLE
ZON-6373: Boomarkable content

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -427,9 +427,7 @@ components:
               # format: uri
               example: "https://www.zeit.de/my/article"
             uuid:
-              type: string
-              description: "The uuid of the content object including the `{urn:uuid:}` prefix"
-              example: "{urn:uuid:26024919-417f-4952-8801-70220d489078}"
+              $ref: "#/components/schemas/UUID"
             image:
               $ref: "#/components/schemas/Image"
             authorImage:

--- a/api.yaml
+++ b/api.yaml
@@ -668,7 +668,7 @@ components:
         - device
         - tile
       properties:
-          type: 
+          type:
             type: string
             enum:
               - adplace

--- a/api.yaml
+++ b/api.yaml
@@ -489,6 +489,9 @@ components:
                   # format: uri
                   description: "URL directly to the comment area of the article"
                   example: "https://www.zeit.de/my/article#comments"
+            bookmarkable:
+              type: boolean
+              example: true
     CenterpageTeaser:
       description: "A teaser module references/represents an article content object"
       allOf:


### PR DESCRIPTION
### Was erledigt dieser PR?

Content der auf CPs eingebunden ist, soll wissen, ob er bookmarkable ist, oder nicht.

### Wo geht's los?

`api.yaml`

### Wie kann getestet werden?

in zeit.web, wenn der PR gemerged ist
`bin/test zeit.web/src/zeit/web/app/test/test_centerpage.py -sk test_teaser_contains_bookmarkable_property `

### Relevante Tickets

https://zeit-online.atlassian.net/browse/ZON-6373
