### PR TITLE
ZON-6277: provide information about user

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -884,13 +884,6 @@ components:
       properties:
         ssoid:
           type: integer
-        status:
-          type: string
-          description: which state the user account is in
-          enum:
-            - active
-            - premod_temporary
-            - blocked
         username:
           type: string
         firstname:
@@ -900,11 +893,6 @@ components:
         avatar:
           type: string
           description: URL to the image
-        created:
-          type: string
-          format: date-time
-          description: "Timestamp when the user account has been created"
-          example: "2019-12-31T13:12:00Z"
 
   securitySchemes:
     default:

--- a/api.yaml
+++ b/api.yaml
@@ -253,6 +253,23 @@ paths:
                 ]}
               ]}
 
+  /user:
+    get:
+      security:
+        - cookieAuthProduction: []
+        - cookieAuthStaging: []
+      tags:
+        - user
+      summary: "Returns information about the current user"
+      responses:
+        "200":
+          description: "Information about the currently logged in user"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserInfo"
+        "403":
+          description: "The user is not logged in"
 components:
   requestBodies:
     AppStoreReceipt:
@@ -863,6 +880,31 @@ components:
       type: string
       description: base64 encoded representation of the app store receipt
       format: byte
+    UserInfo:
+      properties:
+        ssoid:
+          type: integer
+        status:
+          type: string
+          description: which state the user account is in
+          enum:
+            - active
+            - premod_temporary
+            - blocked
+        username:
+          type: string
+        firstname:
+          type: string
+        lastname:
+          type: string
+        avatar:
+          type: string
+          description: URL to the image
+        created:
+          type: string
+          format: date-time
+          description: "Timestamp when the user account has been created"
+          example: "2019-12-31T13:12:00Z"
 
   securitySchemes:
     default:


### PR DESCRIPTION
this essentially is a manual and complete version of the auto-generated
spec from the profile server at
https://docs.zeit.de/comment/referenz/rest.html

since that spec is auto-generated (and thus more or less useless, since
it says nothing about the actual content) we recreate it here.

note that we (indirectly) signify the login status via return code. this
may or may not be a desirable behaviour but seems like a good, sparse
initial approach.