### PR TITLE
ZON-6383: Centerpage header

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -298,6 +298,7 @@ components:
               - $ref: "#/components/schemas/CenterpageModuleHTML"
               - $ref: "#/components/schemas/CenterpageAdplace"
               - $ref: "#/components/schemas/CenterpageHeader"
+              - $ref: "#/components/schemas/CenterpageMarkup"
 
     CenterpageElementId:
       type: string
@@ -699,7 +700,14 @@ components:
           type: string
     CenterpageMarkup:
       description: "A list of text"
+      required:
+        - type
+        - text
       properties:
+        type:
+          type: string
+          enum:
+            - 'markup'
         title:
           type: string
         text: 

--- a/api.yaml
+++ b/api.yaml
@@ -691,6 +691,8 @@ components:
           enum:
             - header
         image:
+          $ref: "#/components/schemas/Image"
+        supertitle:
           type: string
         title:
           type: string

--- a/api.yaml
+++ b/api.yaml
@@ -297,6 +297,7 @@ components:
               - $ref: "#/components/schemas/CenterpageTeaserPodcast"
               - $ref: "#/components/schemas/CenterpageModuleHTML"
               - $ref: "#/components/schemas/CenterpageAdplace"
+              - $ref: "#/components/schemas/CenterpageHeader"
 
     CenterpageElementId:
       type: string
@@ -315,6 +316,7 @@ components:
         - teaser-video
         - teaser-podcast
         - html
+        - header
       description: "Type of the cp element"
 
     Image:
@@ -678,6 +680,20 @@ components:
             enum:
               - desktop
               - mobile
+    CenterpageHeader:
+      description: "Header for native centerpages"
+      required:
+        - type
+        - title
+      properties:
+        type:
+          type: string
+          enum:
+            - header
+        image:
+          type: string
+        title:
+          type: string
 
     TabBase:
       required:

--- a/api.yaml
+++ b/api.yaml
@@ -317,6 +317,7 @@ components:
         - teaser-podcast
         - html
         - header
+        - markup
       description: "Type of the cp element"
 
     Image:
@@ -695,6 +696,13 @@ components:
         supertitle:
           type: string
         title:
+          type: string
+    CenterpageMarkup:
+      description: "A list of text"
+      properties:
+        title:
+          type: string
+        text: 
           type: string
 
     TabBase:


### PR DESCRIPTION
### Was erledigt dieser PR?

Erlaubt Einträge für Header und Markups auf Centerpages in Zappi

### Wo geht's los?

`api.yaml`

### Wie kann getestet werden?

in `zeit.web`:
`bin/test zeit.web/src/zeit/web/app/test/test_view_centerpage.py`

### Relevante Tickets

https://zeit-online.atlassian.net/browse/ZON-6383

