### PR TITLE
ZON-6386: include subscriptions in user info

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -894,6 +894,18 @@ components:
         avatar:
           type: string
           description: URL to the image
+        subscriptions:
+          type: array
+          description: |
+            Which subscriptions does the current user have?
+            - "pur": the user should not be tracked and should not
+              see any ads
+            - "digital": the user should be able to see all Z+ content
+          items:
+            type: string
+            enum:
+              - pur
+              - digital
 
   securitySchemes:
     default:


### PR DESCRIPTION
@TStrothjohann passt das so mit den abo bezeichnungen? bin offen fuer vorschlaege.
ich habe mir gedacht, dass wenn wir das einfach als liste mit definiertem vokabular machen, ist es am flexibelsten her. und die clients koennen dann ja einfach sowas machen wie ``if 'pur' in info['subscriptions']``.