### PR TITLE
ZON-6376: Adhandler-information for centerpage

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -351,6 +351,7 @@ components:
           example: "deutschland"
         keywords:
           type: string
+          example: "zeitonline,coronavirus,frankreich,lockdown"
 
 
     Image:

--- a/api.yaml
+++ b/api.yaml
@@ -339,7 +339,6 @@ components:
 
     AdControllerPageInfo:
       type: object
-      nullable: true
       properties:
         level2:
           description: "Level2 property ressort for adplacement"

--- a/api.yaml
+++ b/api.yaml
@@ -348,7 +348,7 @@ components:
         level3:
           description: "Level3 property subressort, name of podcast or series for adplacement"
           type: string
-          example: "deutschland, gesundheit, was_jetzt"
+          example: "deutschland"
         keywords:
           type: string
 

--- a/api.yaml
+++ b/api.yaml
@@ -303,7 +303,7 @@ components:
         bookmarkable:
           type: boolean
           example: true
-        AdControllerPageInfo:
+        adControllerPageInfo:
           $ref: "#/components/schemas/AdControllerPageInfo"
         items:
           type: array

--- a/api.yaml
+++ b/api.yaml
@@ -303,16 +303,8 @@ components:
         bookmarkable:
           type: boolean
           example: true
-        level2:
-          description: "Level2 property ressort for adplacement"
-          type: string
-          example: "politik, wissen, podcasts, news"
-        level3:
-          description: "Level3 property subressort, name of podcast or series for adplacement"
-          type: string
-          example: "deutschland, gesundheit, was_jetzt"
-        keywords:
-          type: string
+        AdControllerPageInfo:
+          $ref: "#/components/schemas/AdControllerPageInfo"
         items:
           type: array
           items:
@@ -344,6 +336,22 @@ components:
         - teaser-podcast
         - html
       description: "Type of the cp element"
+
+    AdControllerPageInfo:
+      type: object
+      nullable: true
+      properties:
+        level2:
+          description: "Level2 property ressort for adplacement"
+          type: string
+          example: "politik, wissen, podcasts, news"
+        level3:
+          description: "Level3 property subressort, name of podcast or series for adplacement"
+          type: string
+          example: "deutschland, gesundheit, was_jetzt"
+        keywords:
+          type: string
+
 
     Image:
       type: object

--- a/api.yaml
+++ b/api.yaml
@@ -303,6 +303,16 @@ components:
         bookmarkable:
           type: boolean
           example: true
+        level2:
+          description: "Level2 property ressort for adplacement"
+          type: string
+          example: "politik, wissen, podcasts, news"
+        level3:
+          description: "Level3 property subressort, name of podcast or series for adplacement"
+          type: string
+          example: "deutschland, gesundheit, was_jetzt"
+        keywords:
+          type: string
         items:
           type: array
           items:

--- a/api.yaml
+++ b/api.yaml
@@ -344,7 +344,7 @@ components:
         level2:
           description: "Level2 property ressort for adplacement"
           type: string
-          example: "politik, wissen, podcasts, news"
+          example: "politik"
         level3:
           description: "Level3 property subressort, name of podcast or series for adplacement"
           type: string


### PR DESCRIPTION
### Was erledigt dieser PR?
Die Informationen level2, level3 und keywords werden von Zappi ausgespielt, damit sie als Ad-Informationen der IQD zur Verfügung gestellt werden können.

### Wo geht's los?
`zeit.web.app.spec.api.yaml`

### Wie kann getestet werden?
in zeit.web:
`$ bin/test zeit.web/src/zeit/web/app/test/test_view_centerpage.py -sk test_zappi_returns_adcontroller_values_on_hp`
oder auf staging nach dem naechsten Release:
`https://zappi.staging.zeit.de/cp/index`
auf Centerpage Ebene `level2`, `level3` und `keywords` kontrollieren

### Relevante Tickets
https://zeit-online.atlassian.net/browse/ZON-6376

