### PR TITLE
MAINT: make the generic 400 responses valid for all resources

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -38,7 +38,7 @@ paths:
                 $ref: "#/components/schemas/Centerpage"
           description: "Success"
         "400":
-          description: "Bad Request"
+          description: "Something was wrong with the request. Check the body for error messages."
         "401":
           description: "Unauthorized"
     post:
@@ -59,7 +59,7 @@ paths:
         "204":
           description: "Saved entry to bookmarks"
         "400":
-          description: "Bad Request"
+          description: "Something was wrong with the request. Check the body for error messages."
         "401":
           description: "Unauthorized"
         "403":
@@ -82,7 +82,7 @@ paths:
         "204":
           description: "Deleted entry from bookmarks"
         "400":
-          description: "Bad Request"
+          description: "Something was wrong with the request. Check the body for error messages."
         "401":
           description: "Unauthorized"
         "403":
@@ -136,6 +136,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Centerpage"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
         "404":
           description: "No centerpage found for the given uuid"
 
@@ -167,6 +169,8 @@ paths:
       responses:
         "204":
           description: "All is well. Enjoy those exclusive articles!"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
         "502":
           description: "The payment server was not reachable."
   /search:
@@ -259,6 +263,8 @@ paths:
                   ]}
                 ]}
               ]}
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
 
   /user:
     get:
@@ -276,6 +282,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserInfo"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
         "401":
           description: "The user is not logged in"
 components:


### PR DESCRIPTION
otherwise we have the absurd situation that openapi **request**
validation  detects an invalid
request, it produces a 400 with a (usually) helpful error message but if
400 is not a valid response, openapi's **response** validation produces
a 500 (without any useful information whatsoever)

this PR simply sprinkles 400 responses over those resources that haven't
declared them yet. henceforth we need to add them to begin with when
configuring new resources.