### PR TITLE
FIX: don't specify ``bytes`` as format for iap payload

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1118,7 +1118,6 @@ components:
     AppStoreReceipt:
       type: string
       description: base64 encoded representation of the app store receipt
-      format: byte
     UserInfo:
       properties:
         ssoid:


### PR DESCRIPTION
while technically correct, in practice it throws validation errors when
posting verbatim values from the actual apple appstore, which are in
fact valid base64 encoded strings.

the pragmatic approach is to drop the formal specification and contend
with an informat spec that says "must be base64 encoded" in the
description