### PR TITLE
MAINT: Remove unused webtrekk cp32 from API specs

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -547,10 +547,6 @@ components:
             - metered
             - paid
           example: "open"
-        32:
-          type: string
-          description: "Protocol"
-          example: "https"
         38:
           type: string
           description: "Channels separated by semicolons"


### PR DESCRIPTION
Follow-up zu https://github.com/ZeitOnline/zeit.web/pull/4547 . 

Reicht das so? Gibts irgendwo noch ein Changelog zu befüllen?

Beim Submodul-Updaten in zeit.web brauche ich dann nochmal Hilfe, bitte.