### PR TITLE
ZON-6472: c1AccessGroup parameter for user endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1198,9 +1198,11 @@ components:
             - "iqdpremium": user has abo
             - "iqdpremium_registered": user is registered user
         c1AccessGroup:
-          type: string
+          type: array
           nullable: true
           description: CeleraOne access group
+          items:
+            type: string
 
   securitySchemes:
     default:

--- a/api.yaml
+++ b/api.yaml
@@ -1197,6 +1197,10 @@ components:
             Extra parameter to identify
             - "iqdpremium": user has abo
             - "iqdpremium_registered": user is registered user
+        c1AccessGroup:
+          type: string
+          nullable: true
+          description: CeleraOne access group
 
   securitySchemes:
     default:


### PR DESCRIPTION
Um festzustellen ob der Nutzer dynamisch ist, benötigen wir den Parameter `c1AccessGroup` für den Nutzerendpunkt. Perspektivisch sollen hier auch weitere Werte für a-b-Tests möglich sein (Absprache mit @TStrothjohann).