### PR TITLE
added zon-teaser-upright to teaser layout enum

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -621,6 +621,7 @@ components:
                 - zon-teaser-classic
                 - zon-teaser-list
                 - zon-teaser-printbox
+                - zon-teaser-upright
                 - zon-teaser-small
                 - zon-teaser-small-compact
                 - zon-teaser-square


### PR DESCRIPTION
Needed for correct caching in ZONA tab story