### PR TITLE
added story area

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -877,6 +877,7 @@ components:
                 - headed
                 - headed-light
                 - standard
+                - story
                 - tab
                 - tabpanel
             items:


### PR DESCRIPTION
zon-teaser-upright belongs into it's fancy new ZONA-only story area, which should be allowed.