### PR TITLE
added two area layouts

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -908,6 +908,7 @@ components:
                 - duo
                 - headed
                 - headed-light
+                - headed-fixed-height
                 - standard
                 - story
                 - tab


### PR DESCRIPTION
I have agreed with Andi and Pavel from Prepublic that it would be best two introduce a new area type for swipeables with fixed heights since headed(-light) is a very comlex module in both apps because of the variety of heights that have to be handled.