### PR TITLE
Allow zon-teaser-stripe

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -633,6 +633,7 @@ components:
                 - zon-teaser-square-compact
                 - zon-teaser-standard
                 - zon-teaser-standard-compact
+                - zon-teaser-stripe
                 - zon-teaser-wide
               description: "How to display this teaser (e.g large/small)"
             title:


### PR DESCRIPTION
I'm introducing zon-teaser-stripe as teaser layout for flat stripe-like teasers in the new audio tab of the ZON App.