### PR TITLE
ZO-639: Episode and series images

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -808,6 +808,10 @@ components:
                   type: array
                   items:
                     $ref: "#/components/schemas/AudioConnection"
+            episodeImage:
+              $ref: "#/components/schemas/Image"
+            seriesImage:
+              $ref: "#/components/schemas/Image"
     CenterpageTeaserAudio:
       description: "A teaser module references/represents an article content object with premium audio"
       allOf:
@@ -835,6 +839,10 @@ components:
                   # format: uri
                   description: "URL directly to the audio source"
                   example: "https://premium.zeit.de/system/files/DZ/2021/19/audio/19_italien_8842307_8635853_dl.mp3"
+            episodeImage:
+              $ref: "#/components/schemas/Image"
+            seriesImage:
+              $ref: "#/components/schemas/Image"
     CenterpageModuleHTML:
       description: "A non-native module that should be displayed via a web view"
       allOf:


### PR DESCRIPTION
Episode and series image properties for audio and podcast teasers. 