### PR TITLE
Allow new area types and teaser layouts

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -624,6 +624,9 @@ components:
               # @check https://vivi.zeit.de/repository/data/cp-layouts.xml
               enum:
                 - zon-teaser-classic
+                - zon-teaser-cover
+                - headerimage
+                - zon-teaser-link-list-item
                 - zon-teaser-list
                 - zon-teaser-printbox
                 - zon-teaser-upright
@@ -918,6 +921,8 @@ components:
                 - headed
                 - headed-light
                 - headed-fixed-height
+                - link-list
+                - podcast-grid
                 - standard
                 - story
                 - tab

--- a/api.yaml
+++ b/api.yaml
@@ -626,7 +626,7 @@ components:
                 - zon-teaser-classic
                 - zon-teaser-cover
                 - headerimage
-                - zon-teaser-link-list-item
+                - zon-teaser-link
                 - zon-teaser-list
                 - zon-teaser-podcast-small
                 - zon-teaser-printbox


### PR DESCRIPTION
In this change I'm introducing new area types `link-list` and `podcast-grid`. I'm also adding teaser layouts `headerimage` aka "Panorama Aufmacher" in zeit.web, `zon-teaser-link-list-item` and `zon-teaser-cover`. All of them are needed to build the new audio tab's podcast overview.