### PR TITLE
ZO-1049: Implement structure summary schema

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -311,6 +311,17 @@ components:
       description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
       example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda} or d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda"
 
+    Structure:
+      type: object
+      properties:
+        tabs:
+          type: array
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/TabCenterpage"
+              - $ref: "#/components/schemas/TabMenu"
+              - $ref: "#/components/schemas/TabStory"
+
     Centerpage:
       type: object
       properties:


### PR DESCRIPTION
Um in vivi die structure (z.B https://vivi.staging.zeit.de/repository/data/app/0-3-2/structure) validieren zu können, wird ein übergeordneter Schema Typ benötigt, in dem die entsprechenden Subschemata referenziert werden. 