### PR TITLE
ZO-2035: Standard-headed area layout

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -955,6 +955,7 @@ components:
                 - podcast-episode-list
                 - podcast-grid
                 - standard
+                - standard-headed
                 - story
                 - tab
                 - tabpanel


### PR DESCRIPTION
In order to show linked titles above lists of teasers, I need a new area layout. I would call it standard-headed because “headed” areas are well known and standard areas, too.