### PR TITLE
add MenuItemBase type menu-item-tab-start

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1173,6 +1173,7 @@ components:
             - menu-item-web
             - menu-item-browser
             - menu-item-submenu
+            - menu-item-tab-start
         icon:
           type: object
           properties:


### PR DESCRIPTION
The new menu usually has a menu-item, which on click restores the initial state of the current tab. It's not opening a web site, cp or native view.