### PR TITLE
ZO-4296: Add 'freebies' routes

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -169,7 +169,56 @@ paths:
           description: "Something was wrong with the request. Check the body for error messages."
         "404":
           description: "No centerpage found for the given uuid"
-
+  /freebies:
+    get:
+      security:
+        - cookieAuthProduction: []
+        - cookieAuthStaging: []
+      summary: "Returns the list of freebies"
+      tags:
+        - freebies
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Freebie"
+          description: "Success"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "401":
+          description: "Unauthorized"
+        "503":
+          description: "Service unavailable"
+    post:
+      security:
+        - cookieAuthProduction: []
+        - cookieAuthStaging: []
+      summary: Add a new freebie
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  $ref:   "#/components/schemas/UUID"
+                path:
+                  type: string
+      responses:
+        "201":
+          description: "Saved entry to freebies"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "502":
+          description: "Bad gateway"
+        "503":
+          description: "Service unavailable"
   /iap/receipts/{platform}:
     post:
       parameters:
@@ -332,6 +381,13 @@ paths:
 components:
   requestBodies:
     AppStoreReceipt:
+      content:
+        "text/plain": {
+          "schema": {
+            "$ref": "#/components/schemas/AppStoreReceipt"
+          }
+        }
+    FreebiePayload:
       content:
         "text/plain": {
           "schema": {
@@ -1533,6 +1589,13 @@ components:
             Extra parameter to identify
             - "iqdpremium": user has abo
             - "iqdpremium_registered": user is registered user
+
+    Freebie:
+      properties:
+        content:
+          $ref: "#/components/schemas/UUID"
+        path:
+          type: string
 
   securitySchemes:
     default:

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -170,12 +170,18 @@ paths:
         "404":
           description: "No centerpage found for the given uuid"
 
-  /freebies:
+  /freebies/{path}:
     get:
+      parameters:
+        - in: path
+          name: path
+          required: true
+          schema:
+            type: string
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: "Returns the list of freebies"
+      summary: "Returns the list of items"
       tags:
         - freebies
       responses:
@@ -183,7 +189,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Freebie"
+                oneOf:
+                  - $ref: "#/components/schemas/Freebie"
+                  - $ref: "#/components/schemas/Allowance"
           description: "Success"
         "400":
           description: "Bad Request"
@@ -192,6 +200,12 @@ paths:
         "500":
           description: "Internal server error"
     post:
+      parameters:
+        - in: path
+          name: path
+          required: true
+          schema:
+            type: string
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
@@ -199,39 +213,12 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                content:
-                  $ref:   "#/components/schemas/UUID"
-                path:
-                  type: string
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FreebiePost"
       responses:
         "201":
           description: "Saved entry to freebies"
-        "400":
-          description: "Bad Request"
-        "401":
-          description: "Unauthorized"
-        "500":
-          description: "Internal server error"
-
-  /freebies/allowance:
-    get:
-      security:
-        - cookieAuthProduction: []
-        - cookieAuthStaging: []
-      summary: "Returns the list of allowance"
-      tags:
-        - freebies
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Allowance"
-          description: "Success"
         "400":
           description: "Bad Request"
         "401":
@@ -1604,22 +1591,53 @@ components:
             - "iqdpremium_registered": user is registered user
 
     Freebie:
+      type: array
+      items:
+        type: object
+        required:
+          - token
+          - content
+          - path
+          - created
+        properties:
+          token:
+            type: string
+            example: "8116c8ea"
+          content:
+            $ref: "#/components/schemas/UUID"
+          path:
+            type: string
+            example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
+          created:
+            type: string
+            example: "2023-11-29T11:42:32.452605+00:00"
+
+    FreebiePost:
+      type: object
+      required:
+        - content
+        - path
       properties:
-        token:
-          type: string
         content:
           $ref: "#/components/schemas/UUID"
         path:
           type: string
-        created:
-          type: string
+          example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
 
     Allowance:
-      properties:
-        allowance:
-          type: integer
-        used:
-          type: integer
+      type: array
+      items:
+        type: object
+        required:
+          - allowance
+          - used
+        properties:
+          allowance:
+            type: integer
+            example: 100
+          used:
+            type: integer
+            example: 2
 
   securitySchemes:
     default:

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -183,7 +183,26 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Freebie"
+                type: array
+                items:
+                  type: object
+                  required:
+                    - token
+                    - content
+                    - path
+                    - created
+                  properties:
+                    token:
+                      type: string
+                      example: "8116c8ea"
+                    content:
+                      $ref: "#/components/schemas/UUID"
+                    path:
+                      type: string
+                      example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
+                    created:
+                      type: string
+                      example: "2023-11-29T11:42:32.452605+00:00"
           description: "Success"
         "400":
           description: "Bad Request"
@@ -201,7 +220,16 @@ paths:
         content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FreebiePost"
+                type: object
+                required:
+                  - content
+                  - path
+                properties:
+                  content:
+                    $ref: "#/components/schemas/UUID"
+                  path:
+                    type: string
+                    example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
       responses:
         "201":
           description: "Saved entry to freebies"
@@ -225,7 +253,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Allowance"
+                type: array
+                items:
+                  type: object
+                  required:
+                    - allowance
+                    - used
+                  properties:
+                    allowance:
+                      type: integer
+                      example: 100
+                    used:
+                      type: integer
+                      example: 2
           description: "Success"
         "400":
           description: "Bad Request"
@@ -1597,55 +1637,6 @@ components:
             Extra parameter to identify
             - "iqdpremium": user has abo
             - "iqdpremium_registered": user is registered user
-
-    Freebie:
-      type: array
-      items:
-        type: object
-        required:
-          - token
-          - content
-          - path
-          - created
-        properties:
-          token:
-            type: string
-            example: "8116c8ea"
-          content:
-            $ref: "#/components/schemas/UUID"
-          path:
-            type: string
-            example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
-          created:
-            type: string
-            example: "2023-11-29T11:42:32.452605+00:00"
-
-    FreebiePost:
-      type: object
-      required:
-        - content
-        - path
-      properties:
-        content:
-          $ref: "#/components/schemas/UUID"
-        path:
-          type: string
-          example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
-
-    Allowance:
-      type: array
-      items:
-        type: object
-        required:
-          - allowance
-          - used
-        properties:
-          allowance:
-            type: integer
-            example: 100
-          used:
-            type: integer
-            example: 2
 
   securitySchemes:
     default:

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -186,13 +186,11 @@ paths:
                 $ref: "#/components/schemas/Freebie"
           description: "Success"
         "400":
-          description: "Something was wrong with the request. Check the body for error messages."
+          description: "Bad Request"
         "401":
           description: "Unauthorized"
         "500":
           description: "Internal server error"
-        "503":
-          description: "Service unavailable"
     post:
       security:
         - cookieAuthProduction: []
@@ -213,15 +211,11 @@ paths:
         "201":
           description: "Saved entry to freebies"
         "400":
-          description: "Something was wrong with the request. Check the body for error messages."
+          description: "Bad Request"
         "401":
           description: "Unauthorized"
-        "403":
-          description: "Forbidden"
-        "502":
-          description: "Bad gateway"
-        "503":
-          description: "Service unavailable"
+        "500":
+          description: "Internal server error"
 
   /freebies/allowance:
     get:
@@ -239,11 +233,11 @@ paths:
                 $ref: "#/components/schemas/Allowance"
           description: "Success"
         "400":
-          description: "Something was wrong with the request. Check the body for error messages."
+          description: "Bad Request"
         "401":
           description: "Unauthorized"
-        "503":
-          description: "Service unavailable"
+        "500":
+          description: "Internal server error"
 
   /iap/receipts/{platform}:
     post:

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -176,6 +176,7 @@ paths:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
       summary: "Returns the list of freebies"
+      operationId: getFreebies
       tags:
         - freebies
       responses:
@@ -215,6 +216,9 @@ paths:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
       summary: Add a new freebie
+      operationId: generateFreebie
+      tags:
+        - freebies
       requestBody:
         required: true
         content:
@@ -246,6 +250,7 @@ paths:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
       summary: "Returns the list of allowance"
+      operationId: getMonthlyAllowance
       tags:
         - freebies
       responses:
@@ -1697,3 +1702,9 @@ components:
       type: apiKey
       in: cookie
       name: my_sso_cookie
+
+tags:
+  - name: freebies
+    description: API to share articles
+    externalDocs:
+      url: https://docs.zeit.de/freebies/

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -170,7 +170,7 @@ paths:
         "404":
           description: "No centerpage found for the given uuid"
 
-  /freebies:
+  /freebies/freebies:
     get:
       security:
         - cookieAuthProduction: []

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -274,6 +274,49 @@ paths:
         "500":
           description: "Internal server error"
 
+  /freebies/rpc/check:
+    post:
+      summary: "Validate a freebie"
+      operationId: checkFreebie
+      tags:
+        - freebies
+      requestBody:
+        required: true
+        content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - token
+                  - path
+                properties:
+                  token:
+                    type: string
+                    example: "8116c8ea"
+                  path:
+                    type: string
+                    example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - accessed
+                  - content
+                properties:
+                  accessed:
+                    type: integer
+                    example: 1
+                  content:
+                    $ref: "#/components/schemas/UUID"
+          description: "Success"
+        "400":
+          description: "Bad Request"
+        "404":
+          description: "Expired or non-existing freebie"
+
   /iap/receipts/{platform}:
     post:
       parameters:

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -170,18 +170,12 @@ paths:
         "404":
           description: "No centerpage found for the given uuid"
 
-  /freebies/{path}:
+  /freebies:
     get:
-      parameters:
-        - in: path
-          name: path
-          required: true
-          schema:
-            type: string
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: "Returns the list of items"
+      summary: "Returns the list of freebies"
       tags:
         - freebies
       responses:
@@ -189,9 +183,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/Freebie"
-                  - $ref: "#/components/schemas/Allowance"
+                $ref: "#/components/schemas/Freebie"
           description: "Success"
         "400":
           description: "Bad Request"
@@ -200,12 +192,6 @@ paths:
         "500":
           description: "Internal server error"
     post:
-      parameters:
-        - in: path
-          name: path
-          required: true
-          schema:
-            type: string
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
@@ -219,6 +205,28 @@ paths:
       responses:
         "201":
           description: "Saved entry to freebies"
+        "400":
+          description: "Bad Request"
+        "401":
+          description: "Unauthorized"
+        "500":
+          description: "Internal server error"
+
+  /freebies/allowance:
+    get:
+      security:
+        - cookieAuthProduction: []
+        - cookieAuthStaging: []
+      summary: "Returns the list of allowance"
+      tags:
+        - freebies
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Allowance"
+          description: "Success"
         "400":
           description: "Bad Request"
         "401":

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -209,8 +209,6 @@ paths:
           description: "Bad Request"
         "401":
           description: "Unauthorized"
-        "500":
-          description: "Internal server error"
     post:
       security:
         - cookieAuthProduction: []
@@ -241,8 +239,8 @@ paths:
           description: "Bad Request"
         "401":
           description: "Unauthorized"
-        "500":
-          description: "Internal server error"
+        "429":
+          description: "Monthly limit exceeded"
 
   /freebies/allowance:
     get:
@@ -276,8 +274,6 @@ paths:
           description: "Bad Request"
         "401":
           description: "Unauthorized"
-        "500":
-          description: "Internal server error"
 
   /freebies/rpc/check:
     post:

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -169,6 +169,7 @@ paths:
           description: "Something was wrong with the request. Check the body for error messages."
         "404":
           description: "No centerpage found for the given uuid"
+
   /freebies:
     get:
       security:
@@ -188,6 +189,8 @@ paths:
           description: "Something was wrong with the request. Check the body for error messages."
         "401":
           description: "Unauthorized"
+        "500":
+          description: "Internal server error"
         "503":
           description: "Service unavailable"
     post:
@@ -219,6 +222,29 @@ paths:
           description: "Bad gateway"
         "503":
           description: "Service unavailable"
+
+  /freebies/allowance:
+    get:
+      security:
+        - cookieAuthProduction: []
+        - cookieAuthStaging: []
+      summary: "Returns the list of allowance"
+      tags:
+        - freebies
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Allowance"
+          description: "Success"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "401":
+          description: "Unauthorized"
+        "503":
+          description: "Service unavailable"
+
   /iap/receipts/{platform}:
     post:
       parameters:
@@ -381,13 +407,6 @@ paths:
 components:
   requestBodies:
     AppStoreReceipt:
-      content:
-        "text/plain": {
-          "schema": {
-            "$ref": "#/components/schemas/AppStoreReceipt"
-          }
-        }
-    FreebiePayload:
       content:
         "text/plain": {
           "schema": {
@@ -1592,10 +1611,21 @@ components:
 
     Freebie:
       properties:
+        token:
+          type: string
         content:
           $ref: "#/components/schemas/UUID"
         path:
           type: string
+        created:
+          type: string
+
+    Allowance:
+      properties:
+        allowance:
+          type: integer
+        used:
+          type: integer
 
   securitySchemes:
     default:


### PR DESCRIPTION
Die API Definition für die ['freebies' Routen](https://docs.zeit.de/freebies/onboarding.html#api) wird hinzugefügt.

Siehe [ZO-4296](https://zeit-online.atlassian.net/browse/ZO-4296) & https://github.com/ZeitOnline/zeit.web/pull/7282

[ZO-4296]: https://zeit-online.atlassian.net/browse/ZO-4296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ