### PR TITLE
Allow area layout lead

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1191,6 +1191,7 @@ components:
                 - headed
                 - headed-light
                 - headed-fixed-height
+                - lead
                 - link-list
                 - podcast-episode-list
                 - podcast-grid


### PR DESCRIPTION
In order to show zon-teaser-wide fullwidth in lead positions, they will be placed into a lead area. I therefore allow the lead area in zappi now.