### PR TITLE
allow area layouts dossier and headed-carousel

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1182,8 +1182,10 @@ components:
             layout:
               type: string
               enum:
+                - dossier
                 - duo
                 - headed
+                - headed-carousel
                 - headed-light
                 - headed-fixed-height
                 - lead


### PR DESCRIPTION
Es steht bereits als Abnahmekriterium in der ZO-4579. Ich möchte es hier aber vorwegnehmen, weil die Apps die dossier area bereits darstellen können. Um das neue Layout auf nativen Seiten testen und nutzen zu können, brauche ich diese Anpassung. Sonst sind CPs mit diesen Area Layouts invalide...