### PR TITLE
ZO-4596: Zappi returns read_more_url and topiclinks of centerpages of areas

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1150,13 +1150,31 @@ components:
               nullable: true
               # format: uri
               description: "A section often links to topic pages etc."
-              example: "https://www.zeit.de/thema/coronavirus"
+              example: "https://www.zeit.de/thema/hamburg"
             title:
               type: string
               nullable: true
               example: "This is a simple title"
             items:
               type: array
+            topiclinks:
+              nullable: true
+              items:
+                $ref: "#/components/schemas/CenterpageAreaTopicLink"
+
+    CenterpageAreaTopicLink:
+      description: "Links to topicpage"
+      type: object
+      required:
+        - label
+        - link
+      properties:
+        label:
+          type: string
+          example: "Hongkong"
+        link:
+          type: string
+          example: https://www.zeit.de/schlagworte/orte/hongkong/index"
 
     CenterpageRegion:
       allOf:


### PR DESCRIPTION
ich habe die Auslieferung der Daten in der AreaBase verortet, da wir abgesprochen hatten, dass das für alle Areas gelten soll.

![panik](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbmdieXJlMG05dXczYXA4ZDFuNm82anVmbDRjbHJ3Y2QwMWVrems4ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/h5JpPmYQsan1QqTeUE/giphy.gif)