### PR TITLE
ZO-4595: Add supertitle to area specs

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1155,6 +1155,10 @@ components:
               type: string
               nullable: true
               example: "This is a simple title"
+            supertitle:
+              type: string
+              nullable: true
+              example: "Das Beste aus Z+"
             items:
               type: array
             topiclinks:


### PR DESCRIPTION
https://zeit-online.atlassian.net/browse/ZO-4579 sagt, dass das JSON für Areas auch die Spitzmarke (`supertitle`) enthalten soll. Dieser PR bereitet die Specs dafür vor. Der Output wird in https://github.com/ZeitOnline/zeit.web/pull/7615 umgesetzt.

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY3o5bXQ0cGw0MzNhd2xzajJka3E2Yjdncm80bjhhcmN3dTUyeTM2dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/db2Ei6MEBTzsk/giphy.gif)