### PR TITLE
ZONIQD-13: Update api.yaml with new iqdpremium keywords

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1748,8 +1748,8 @@ components:
           nullable: true
           description: |
             Extra parameter to identify
-            - "iqdpremium": user has abo
-            - "iqdpremium_registered": user is registered user
+            - "iqdpaid": user has abo
+            - "iqdlogin": user is registered user
 
     summaries:
       description: properties of "summary" row


### PR DESCRIPTION
**Zur Zeit "don't merge" weil die IQD es sich ggf. nochmal anders überlegt.** 🤷‍♂️ 

Auf Wunsch der IQD nach Synchronität unten den Mandanten werden die Keywords zur Identifizierung eingeloggter und Abo-User*innen angepasst. Aus "iqdpremium" wird "iqdpaid" und aus "iqdpremium_registered" wird "iqdlogin".

Ticket: <https://zeit-online.atlassian.net/browse/ZONIQD-13>

PR in zeit.web: <https://github.com/ZeitOnline/zeit.web/pull/7644>