### PR TITLE
ZO-4579: Add readmore label to headed area

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1206,6 +1206,10 @@ components:
               nullable: true
               items:
                 $ref: "#/components/schemas/CenterpageAreaTopicLink"
+            readmore:
+              type: string
+              nullable: true
+              example: "Mehr zum Thema Simple Title"
 
     CenterpageAreaTopicLink:
       description: "Links to topicpage"


### PR DESCRIPTION
https://zeit-online.atlassian.net/browse/ZO-4579

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNzF1MTlmYnFtZDZ1ZW83b3MwanJjYml4NXR0cDZmNGRjN2oxdWlxeiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/b3VxXaoekw1pbGXoj7/giphy-downsized.gif)