### PR TITLE
Allow new audio teaser layouts

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -991,6 +991,10 @@ components:
               type: string
               # @check https://vivi.zeit.de/repository/data/cp-layouts.xml
               enum:
+                - zon-teaser-audio-xl
+                - zon-teaser-audio-l
+                - zon-teaser-audio-m
+                - zon-teaser-audio-s
                 - zon-teaser-classic
                 - zon-teaser-cover
                 - zon-teaser-panorama


### PR DESCRIPTION
For the rebrush of the app-only audio tab, we would like to introduce new teaser names.

https://zeit-online.atlassian.net/browse/ZO-5875