### PR TITLE
WCM-352_update-zappi-specs-for-playlists

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1582,7 +1582,6 @@ components:
       description: "Header for native centerpages"
       required:
         - type
-        - title
       properties:
         id:
           $ref: "#/components/schemas/CenterpageElementId"


### PR DESCRIPTION
Proposal...
linked-uuid as property of areaBase
region layout playlist
teaser layout audio-playlist-m-cover

Areas and headers don't have to have titles. Let's not require these properties anymore. It's causing validation errors.