### PR TITLE
fix(content): remove security restrictions for `/teaser` endpoint

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -25,9 +25,6 @@ servers:
 paths:
   /teaser/{uuid}:
     get:
-      security:
-          - cookieAuthProduction: []
-          - cookieAuthStaging: []
       description: Returns a single teaser element
       parameters:
         - in: path


### PR DESCRIPTION
It should be accessible for anonymous users as well.

Refs: ZO-4493, #136, #139