### PR TITLE
WCM-352: allow audio-playlist-m teaser layout

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1203,6 +1203,7 @@ components:
                 - audio-tile-m-collapsed
                 - audio-listitem-s-expanded
                 - audio-listitem-m-expanded
+                - audio-playlist-m
                 - audio-playlist-m-cover
                 - zon-teaser-classic
                 - zon-teaser-cover


### PR DESCRIPTION
For playlists that are no volumes we don't want to use a different layout in the apps. It's called audio-playlist-m.