### PR TITLE
allow audio-playlist-header and audio-playlist-tile-l

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1203,8 +1203,12 @@ components:
                 - audio-tile-m-collapsed
                 - audio-listitem-s-expanded
                 - audio-listitem-m-expanded
+                - audio-playlist-header
+                - audio-playlist-header-cover
                 - audio-playlist-m
                 - audio-playlist-m-cover
+                - audio-playlist-tile-l
+                - audio-playlist-tile-l-cover
                 - zon-teaser-classic
                 - zon-teaser-cover
                 - zon-teaser-panorama


### PR DESCRIPTION
Ticket: https://zeit-online.atlassian.net/browse/WCM-439

To present playlists as hero teasers and cp headers we need new teaser layouts...
                - audio-playlist-header
                - audio-playlist-header-cover
                - audio-playlist-tile-l
                - audio-playlist-tile-l-cover