### PR TITLE
fix: add http status 409 to spec which is used for duplicates

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -119,6 +119,8 @@ paths:
           description: "Unauthorized (to save bookmark)"
         "403":
           description: "Forbidden (to save bookmark)"
+        "409":
+          description: "Bookmark already exists. You can't bookmark the same document twice."
         "502":
           description: "Bad gateway (when saving bookmark)"
         "503":


### PR DESCRIPTION
Entsprechend der [Merkl-API](https://github.com/ZeitOnline/merkl/pull/469) auch hier die Ergänzung des Status 409, welcher beim Posten eines Bookmarks durch einen User zurückgegeben wird, wenn der Bookmark schon existiert. In Zappi führt das sonst zu einem 500er durch die Openapi Validierung.

![](https://c.tenor.com/Jp9ScKz-Y-kAAAAd/tenor.gif)