### PR TITLE
WCM-557: Allow GalleryTeaser as response for the JSON teaser endpoint

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -39,6 +39,7 @@ paths:
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/CenterpageTeaser"
+                  - $ref: "#/components/schemas/CenterpageTeaserGallery"
                   - $ref: "#/components/schemas/CenterpageTeaserVideo"
                   - $ref: "#/components/schemas/CenterpageTeaserPodcast"
                   - $ref: "#/components/schemas/CenterpageTeaserAudio"


### PR DESCRIPTION
Der Content Endpunkt in Zappi, der Teaser-Infos als JSON ausgibt, wirft Fehler für Galerie-Teaser. 
(Siehe Meldung und HNY Link im Ticket https://zeit-online.atlassian.net/browse/WCM-557.)
Auf Devproduction zu sehen unter http://localhost:9090/app/content/teaser/440f30fe-47b9-4edf-852c-5347bb614cfc .
Dieser PR fixt das.


![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcGE4Zmpscmc0ZjAwZGE5YmJrdGRvNjVzdDhkdWFudDFiMmNhZG9kdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/aMipyIAtahg21LoFwU/giphy-downsized.gif)