### PR TITLE
ZO-4648: declare status code for missing user entitlement

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -415,6 +415,8 @@ paths:
           description: "Bad Request"
         "401":
           description: "Unauthorized"
+        "403":
+          description: "Forbidden"
         "429":
           description: "Monthly limit exceeded"
 


### PR DESCRIPTION
Mit https://github.com/ZeitOnline/freebies/pull/150 kann die 'freebies' API jetzt auch 403er liefern.