### PR TITLE
ES-72: Add CenterpageExtra (CPExtra) to Centerpage items

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -825,6 +825,7 @@ components:
               - $ref: "#/components/schemas/CenterpageAdplace"
               - $ref: "#/components/schemas/CenterpageHeader"
               - $ref: "#/components/schemas/CenterpageMarkup"
+              - $ref: "#/components/schemas/CenterpageExtra"
             discriminator:
               propertyName: type
               mapping:
@@ -840,6 +841,7 @@ components:
                 adplace: "#/components/schemas/CenterpageAdplace"
                 header: "#/components/schemas/CenterpageHeader"
                 markup: "#/components/schemas/CenterpageMarkup"
+                cpextra: "#/components/schemas/CenterpageExtra"
 
     CenterpageElementId:
       type: string
@@ -1618,6 +1620,7 @@ components:
                     teaser-podcast: "#/components/schemas/CenterpageTeaserPodcast"
                     teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
                     html: "#/components/schemas/CenterpageModuleHTML"
+                    cpextra: "#/components/schemas/CenterpageExtra"
             trackingData:
               type: object
               properties:
@@ -1678,6 +1681,23 @@ components:
         title:
           type: string
         text:
+          type: string
+
+    CenterpageExtra:
+      description: "CPExtra: additional content block for centerpages that can contain anything"
+      required:
+        - id
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - cpextra
+        id:
+          description: "Unique ID of the CPExtra"
+          type: string
+        value:
+          description: "The content type this CPExtra represents"
           type: string
 
     TabBase:

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1689,6 +1689,7 @@ components:
       description: "CPExtra: additional content block for centerpages that can contain anything"
       required:
         - type
+        - cpextra
       properties:
         id:
           $ref: "#/components/schemas/CenterpageElementId"

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -864,6 +864,7 @@ components:
         - html
         - header
         - markup
+        - cpextra
       description: "Type of the cp element"
 
     AdControllerPageInfo:
@@ -1610,6 +1611,7 @@ components:
                   - $ref: "#/components/schemas/CenterpageTeaserPodcast"
                   - $ref: "#/components/schemas/CenterpageTeaserAudio"
                   - $ref: "#/components/schemas/CenterpageModuleHTML"
+                  - $ref: "#/components/schemas/CenterpageExtra"
                 discriminator:
                   propertyName: type
                   mapping:
@@ -1686,17 +1688,15 @@ components:
     CenterpageExtra:
       description: "CPExtra: additional content block for centerpages that can contain anything"
       required:
-        - id
         - type
       properties:
+        id:
+          $ref: "#/components/schemas/CenterpageElementId"
         type:
           type: string
           enum:
             - cpextra
-        id:
-          description: "Unique ID of the CPExtra"
-          type: string
-        value:
+        cpextra:
           description: "The content type this CPExtra represents"
           type: string
 


### PR DESCRIPTION
Fügt die API Docs für die Integration von CPExtras als Teil der `items` einer Centerpage im `/cp`-Endpunkt hinzu.

Siehe Beschreibung in https://github.com/ZeitOnline/zeit.web/pull/8742