### PR TITLE
MAINT: format api.yaml according to ZON standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,25 +1,25 @@
-# @see: http://EditorConfig.org
+# Maintained in https://github.com/ZeitOnline/frontend-code-style/
+# Consider adding any changes there first.
 
-# top-most EditorConfig file
 root = true
 
-# Global styles
 [*]
 charset = utf-8
 end_of_line = lf
 indent_size = 4
-indent_style = space
+indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
+quote_type = single
+max_line_length = 100
 
-# YAML
-[*.yaml]
-indent_size = 2
+[*.{sass,scss,css}]
+quote_type = double
 
-# Markdown
 [*.md]
+indent_size = 2
 trim_trailing_whitespace = false
 
-# make
-[Makefile]
-indent_style = tab
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = true
 quote_type = single
 max_line_length = 100
 
-[*.{sass,scss,css}]
+[*.{sass,scss,css,yaml,yml}]
 quote_type = double
 
 [*.md]

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# 2025-04-08 format api.yaml after introduction of common ZON frontend-code-style
+9a29d24486783705139bede6b4a53909bcabe337

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # 2025-04-08 format api.yaml after introduction of common ZON frontend-code-style
-9a29d24486783705139bede6b4a53909bcabe337
+80fc316c7cd5653e7cc46361e69d03992b909214
+492883e9d13a9f194c2d51bfe0e7aefb04af4ad5

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1,26 +1,26 @@
 openapi: 3.0.2
 info:
-  description: "This is the API description for the ZON-App (iOS and Android)"
-  version: "0.3.1"
-  title: "ZON App API"
+  description: 'This is the API description for the ZON-App (iOS and Android)'
+  version: '0.3.1'
+  title: 'ZON App API'
   contact:
-    email: "internet-technik@zeit.de"
+    email: 'internet-technik@zeit.de'
 
 servers:
-  - url: "https://zappi.zeit.de/{version}"
-    description: "Production"
+  - url: 'https://zappi.zeit.de/{version}'
+    description: 'Production'
     variables:
       version:
-        default: "0.3.1"
+        default: '0.3.1'
         enum: # list older still available versions here
-          - "0.3.1"
-  - url: "https://zappi.staging.zeit.de/{version}"
-    description: "Staging"
+          - '0.3.1'
+  - url: 'https://zappi.staging.zeit.de/{version}'
+    description: 'Staging'
     variables:
       version:
-        default: "0.3.1"
+        default: '0.3.1'
         enum:
-          - "0.3.1"
+          - '0.3.1'
 
 paths:
   /content/teaser/{uuid}:
@@ -31,27 +31,27 @@ paths:
           name: uuid
           required: true
           schema:
-            $ref: "#/components/schemas/UUID"
+            $ref: '#/components/schemas/UUID'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: "#/components/schemas/CenterpageTeaser"
-                  - $ref: "#/components/schemas/CenterpageTeaserGallery"
-                  - $ref: "#/components/schemas/CenterpageTeaserVideo"
-                  - $ref: "#/components/schemas/CenterpageTeaserPodcast"
-                  - $ref: "#/components/schemas/CenterpageTeaserAudio"
-          description: "Success"
-        "400":
-          description: "Something was wrong. Check the body for error messages."
-        "401":
-          description: "Unauthorized to get teaser"
-        "404":
-          description: "Not found"
-        "503":
-          description: "Service unavailable"
+                  - $ref: '#/components/schemas/CenterpageTeaser'
+                  - $ref: '#/components/schemas/CenterpageTeaserGallery'
+                  - $ref: '#/components/schemas/CenterpageTeaserVideo'
+                  - $ref: '#/components/schemas/CenterpageTeaserPodcast'
+                  - $ref: '#/components/schemas/CenterpageTeaserAudio'
+          description: 'Success'
+        '400':
+          description: 'Something was wrong. Check the body for error messages.'
+        '401':
+          description: 'Unauthorized to get teaser'
+        '404':
+          description: 'Not found'
+        '503':
+          description: 'Service unavailable'
 
   /merkl/bookmarks:
     get:
@@ -59,8 +59,7 @@ paths:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
       operationId: getBookmarks
-      description:
-        Returns list of bookmarks, optionally filtered by category.<br>
+      description: Returns list of bookmarks, optionally filtered by category.<br>
         Calling this endpoint without parameters returns all bookmarks.<br>
         To get only bookmarks by a given category, call this endpoint with the `category` parameter.
       parameters:
@@ -70,24 +69,24 @@ paths:
           schema:
             type: string
             description: Category
-            example: "podcast"
+            example: 'podcast'
           description: category to filter list of bookmarks
-          example: "?category=podcast"
+          example: '?category=podcast'
       tags:
         - bookmarks
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/bookmark"
-          description: "Return list of bookmarks, optionally filtered by category"
-        "400":
-          description: "Something went wrong with the request to get bookmarks. Check the body for error messages."
-        "401":
-          description: "Unauthorized (to get bookmarks)"
-        "503":
-          description: "Service unavailable (when getting bookmarks)"
+                $ref: '#/components/schemas/bookmark'
+          description: 'Return list of bookmarks, optionally filtered by category'
+        '400':
+          description: 'Something went wrong with the request to get bookmarks. Check the body for error messages.'
+        '401':
+          description: 'Unauthorized (to get bookmarks)'
+        '503':
+          description: 'Service unavailable (when getting bookmarks)'
     post:
       security:
         - cookieAuthProduction: []
@@ -105,38 +104,37 @@ paths:
               type: object
               properties:
                 uuid:
-                  $ref: "#/components/schemas/UUID"
+                  $ref: '#/components/schemas/UUID'
               required:
                 - uuid
               additionalProperties: false
       responses:
-        "201":
-          description: "Saved entry to bookmarks (returning it)"
-        "204":
-          description: "Saved entry to bookmarks (without returning it)"
-        "400":
-          description: "Something went wrong with the request to save bookmark. Check the body for error messages."
-        "401":
-          description: "Unauthorized (to save bookmark)"
-        "403":
-          description: "Forbidden (to save bookmark)"
-        "409":
+        '201':
+          description: 'Saved entry to bookmarks (returning it)'
+        '204':
+          description: 'Saved entry to bookmarks (without returning it)'
+        '400':
+          description: 'Something went wrong with the request to save bookmark. Check the body for error messages.'
+        '401':
+          description: 'Unauthorized (to save bookmark)'
+        '403':
+          description: 'Forbidden (to save bookmark)'
+        '409':
           description: "Bookmark already exists. You can't bookmark the same document twice."
-        "502":
-          description: "Bad gateway (when saving bookmark)"
-        "503":
-          description: "Service unavailable (when saving bookmark)"
+        '502':
+          description: 'Bad gateway (when saving bookmark)'
+        '503':
+          description: 'Service unavailable (when saving bookmark)'
     delete:
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
       operationId: deleteBookmark
-      description:
-        <dl>
-          <dt>Delete one bookmark:</dt>
-          <dd>If you want to delete one specific bookmark, you have to pass its UUID as a parameter.</dd>
-          <dt>Delete all bookmarks:</dt>
-          <dd>To delete all bookmarks, call this endpoint without parameters.</dd>
+      description: <dl>
+        <dt>Delete one bookmark:</dt>
+        <dd>If you want to delete one specific bookmark, you have to pass its UUID as a parameter.</dd>
+        <dt>Delete all bookmarks:</dt>
+        <dd>To delete all bookmarks, call this endpoint without parameters.</dd>
         </dl>
       tags:
         - bookmarks
@@ -145,21 +143,21 @@ paths:
           name: uuid
           required: false
           schema:
-            $ref: "#/components/schemas/uuidfilter"
+            $ref: '#/components/schemas/uuidfilter'
           description: UUID of an article
       responses:
-        "204":
-          description: "Deleted entry from bookmarks or delete all bookmarks, respectively"
-        "400":
-          description: "Something went wrong with the request to delete a bookmark. Check the body for error messages."
-        "401":
-          description: "Unauthorized (to delete bookmark)"
-        "403":
-          description: "Forbidden (to delete bookmark)"
-        "502":
-          description: "Bad gateway (when deleting bookmark)"
-        "503":
-          description: "Service unavailable (when deleting bookmarks)"
+        '204':
+          description: 'Deleted entry from bookmarks or delete all bookmarks, respectively'
+        '400':
+          description: 'Something went wrong with the request to delete a bookmark. Check the body for error messages.'
+        '401':
+          description: 'Unauthorized (to delete bookmark)'
+        '403':
+          description: 'Forbidden (to delete bookmark)'
+        '502':
+          description: 'Bad gateway (when deleting bookmark)'
+        '503':
+          description: 'Service unavailable (when deleting bookmarks)'
 
   /merkl/categories:
     get:
@@ -171,7 +169,7 @@ paths:
       tags:
         - categories
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -189,35 +187,35 @@ paths:
                     - count
                     - name
                   additionalProperties: false
-          description: "Success getting each category name with count of its bookmarks"
-        "400":
-          description: "Something went wrong with the request to get categories. Check the body for error messages."
-        "401":
-          description: "Unauthorized (to get categories)"
-        "503":
-          description: "Service unavailable (when getting categories)"
+          description: 'Success getting each category name with count of its bookmarks'
+        '400':
+          description: 'Something went wrong with the request to get categories. Check the body for error messages.'
+        '401':
+          description: 'Unauthorized (to get categories)'
+        '503':
+          description: 'Service unavailable (when getting categories)'
 
   /bookmarks:
     get:
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: "Returns the list of bookmarks"
+      summary: 'Returns the list of bookmarks'
       tags:
         - bookmarks
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Centerpage"
-          description: "Success"
-        "400":
-          description: "Something was wrong with the request. Check the body for error messages."
-        "401":
-          description: "Unauthorized"
-        "503":
-          description: "Service unavailable"
+                $ref: '#/components/schemas/Centerpage'
+          description: 'Success'
+        '400':
+          description: 'Something was wrong with the request. Check the body for error messages.'
+        '401':
+          description: 'Unauthorized'
+        '503':
+          description: 'Service unavailable'
     post:
       security:
         - cookieAuthProduction: []
@@ -231,22 +229,22 @@ paths:
               type: object
               properties:
                 id:
-                  $ref: "#/components/schemas/UUID"
+                  $ref: '#/components/schemas/UUID'
       responses:
-        "201":
-          description: "Saved entry to bookmarks"
-        "204":
-          description: "Saved entry to bookmarks"
-        "400":
-          description: "Something was wrong with the request. Check the body for error messages."
-        "401":
-          description: "Unauthorized"
-        "403":
-          description: "Forbidden"
-        "502":
-          description: "Bad gateway"
-        "503":
-          description: "Service unavailable"
+        '201':
+          description: 'Saved entry to bookmarks'
+        '204':
+          description: 'Saved entry to bookmarks'
+        '400':
+          description: 'Something was wrong with the request. Check the body for error messages.'
+        '401':
+          description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
+        '502':
+          description: 'Bad gateway'
+        '503':
+          description: 'Service unavailable'
 
   /bookmarks/{uuid}:
     delete:
@@ -258,42 +256,42 @@ paths:
           name: uuid
           required: true
           schema:
-            $ref: "#/components/schemas/UUID"
+            $ref: '#/components/schemas/UUID'
       responses:
-        "204":
-          description: "Deleted entry from bookmarks"
-        "400":
-          description: "Something was wrong with the request. Check the body for error messages."
-        "401":
-          description: "Unauthorized"
-        "403":
-          description: "Forbidden"
-        "502":
-          description: "Bad gateway"
-        "503":
-          description: "Service unavailable"
+        '204':
+          description: 'Deleted entry from bookmarks'
+        '400':
+          description: 'Something was wrong with the request. Check the body for error messages.'
+        '401':
+          description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
+        '502':
+          description: 'Bad gateway'
+        '503':
+          description: 'Service unavailable'
 
   /bookmarks/ids:
     get:
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: "Returns the list of bookmarked ids"
+      summary: 'Returns the list of bookmarked ids'
       tags:
         - bookmarks
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BookmarkIds"
-          description: "Success"
-        "400":
-          description: "Something was wrong with the request. Check the body for error messages."
-        "401":
-          description: "Unauthorized"
-        "503":
-          description: "Service unavailable"
+                $ref: '#/components/schemas/BookmarkIds'
+          description: 'Success'
+        '400':
+          description: 'Something was wrong with the request. Check the body for error messages.'
+        '401':
+          description: 'Unauthorized'
+        '503':
+          description: 'Service unavailable'
 
   /config/{filename}:
     get:
@@ -303,23 +301,23 @@ paths:
           schema:
             type: string
           required: true
-          description: "The filename of the configuration file"
+          description: 'The filename of the configuration file'
       summary: |
         Provides JSON formatted configuration files. These are maintained
         via the CMS and can change independently of API releases.
         By convention, these reside in the folder
         ``https://vivi.zeit.de/repository/static/zona``
       responses:
-        "200":
-          description: "Success"
+        '200':
+          description: 'Success'
           content:
             application/json:
               schema:
                 type: object
-        "400":
-          description: "No valid JSON for this resource"
-        "404":
-          description: "No such configuration file"
+        '400':
+          description: 'No valid JSON for this resource'
+        '404':
+          description: 'No such configuration file'
 
   /cp/{uuid}:
     get:
@@ -327,36 +325,36 @@ paths:
         - in: path
           name: uuid
           schema:
-            $ref: "#/components/schemas/UUID"
+            $ref: '#/components/schemas/UUID'
           required: true
-          description: "UUID from CMS that identifies a CenterPage content object"
+          description: 'UUID from CMS that identifies a CenterPage content object'
 
       tags:
         - cp
-      summary: "Returns the teasers (i.e. content references) on a CenterPage"
+      summary: 'Returns the teasers (i.e. content references) on a CenterPage'
       responses:
-        "200":
-          description: "Success"
+        '200':
+          description: 'Success'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Centerpage"
-        "400":
-          description: "Something was wrong with the request. Check the body for error messages."
-        "404":
-          description: "No centerpage found for the given uuid"
+                $ref: '#/components/schemas/Centerpage'
+        '400':
+          description: 'Something was wrong with the request. Check the body for error messages.'
+        '404':
+          description: 'No centerpage found for the given uuid'
 
   /freebies/freebies:
     get:
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: "Returns the list of freebies"
+      summary: 'Returns the list of freebies'
       operationId: getFreebies
       tags:
         - freebies
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -371,20 +369,20 @@ paths:
                   properties:
                     token:
                       type: string
-                      example: "8116c8ea"
+                      example: '8116c8ea'
                     content:
-                      $ref: "#/components/schemas/UUID"
+                      $ref: '#/components/schemas/UUID'
                     path:
                       type: string
-                      example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
+                      example: '/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources'
                     created:
                       type: string
-                      example: "2023-11-29T11:42:32.452605+00:00"
-          description: "Success"
-        "400":
-          description: "Bad Request"
-        "401":
-          description: "Unauthorized"
+                      example: '2023-11-29T11:42:32.452605+00:00'
+          description: 'Success'
+        '400':
+          description: 'Bad Request'
+        '401':
+          description: 'Unauthorized'
     post:
       security:
         - cookieAuthProduction: []
@@ -396,41 +394,41 @@ paths:
       requestBody:
         required: true
         content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - content
-                  - path
-                properties:
-                  content:
-                    $ref: "#/components/schemas/UUID"
-                  path:
-                    type: string
-                    example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
+          application/json:
+            schema:
+              type: object
+              required:
+                - content
+                - path
+              properties:
+                content:
+                  $ref: '#/components/schemas/UUID'
+                path:
+                  type: string
+                  example: '/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources'
       responses:
-        "201":
-          description: "Saved entry to freebies"
-        "400":
-          description: "Bad Request"
-        "401":
-          description: "Unauthorized"
-        "403":
-          description: "Forbidden"
-        "429":
-          description: "Monthly limit exceeded"
+        '201':
+          description: 'Saved entry to freebies'
+        '400':
+          description: 'Bad Request'
+        '401':
+          description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
+        '429':
+          description: 'Monthly limit exceeded'
 
   /freebies/allowance:
     get:
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: "Returns the list of allowance"
+      summary: 'Returns the list of allowance'
       operationId: getMonthlyAllowance
       tags:
         - freebies
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -447,36 +445,36 @@ paths:
                     used:
                       type: integer
                       example: 2
-          description: "Success"
-        "400":
-          description: "Bad Request"
-        "401":
-          description: "Unauthorized"
+          description: 'Success'
+        '400':
+          description: 'Bad Request'
+        '401':
+          description: 'Unauthorized'
 
   /freebies/rpc/check:
     post:
-      summary: "Validate a freebie"
+      summary: 'Validate a freebie'
       operationId: checkFreebie
       tags:
         - freebies
       requestBody:
         required: true
         content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - token
-                  - path
-                properties:
-                  token:
-                    type: string
-                    example: "8116c8ea"
-                  path:
-                    type: string
-                    example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
+          application/json:
+            schema:
+              type: object
+              required:
+                - token
+                - path
+              properties:
+                token:
+                  type: string
+                  example: '8116c8ea'
+                path:
+                  type: string
+                  example: '/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
@@ -489,12 +487,12 @@ paths:
                     type: integer
                     example: 1
                   content:
-                    $ref: "#/components/schemas/UUID"
-          description: "Success"
-        "400":
-          description: "Bad Request"
-        "404":
-          description: "Expired or non-existing freebie"
+                    $ref: '#/components/schemas/UUID'
+          description: 'Success'
+        '400':
+          description: 'Bad Request'
+        '404':
+          description: 'Expired or non-existing freebie'
 
   /summy/summaries:
     get:
@@ -511,7 +509,7 @@ paths:
             type: string
             pattern: '^eq.[-a-f0-9]+$'
       responses:
-        "200":
+        '200':
           description: return summaries
           content:
             application/json:
@@ -544,10 +542,8 @@ paths:
           name: platform
           required: true
           schema:
-            $ref: "#/components/schemas/AppStoreType"
-      requestBody: {
-        $ref: "#/components/requestBodies/AppStoreReceipt"
-      }
+            $ref: '#/components/schemas/AppStoreType'
+      requestBody: { $ref: '#/components/requestBodies/AppStoreReceipt' }
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
@@ -563,117 +559,267 @@ paths:
           "real" account, the response will have the cookie for that real account set. Clients are expected to notice the
           discrepancy and use the new cookie henceforth.
       responses:
-        "204":
-          description: "All is well. Enjoy those exclusive articles!"
-        "400":
-          description: "Something was wrong with the request. Check the body for error messages."
-        "401":
-          description: "No valid identities were found in the receipt."
-        "502":
-          description: "The payment server was not reachable."
+        '204':
+          description: 'All is well. Enjoy those exclusive articles!'
+        '400':
+          description: 'Something was wrong with the request. Check the body for error messages.'
+        '401':
+          description: 'No valid identities were found in the receipt.'
+        '502':
+          description: 'The payment server was not reachable.'
 
   /search:
-   get:
-    tags:
-      - search
-    summary: "Main entry point for generic search."
-    parameters:
-      - in: query
-        name: q
-        schema:
-          type: string
-        required: true
-        description: "The term that should be searched for"
-    responses:
-      "200":
-        description: "Returns a list of results"
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                adControllerPageInfo:
-                  $ref: "#/components/schemas/AdControllerPageInfo"
-                items:
-                  type: array
+    get:
+      tags:
+        - search
+      summary: 'Main entry point for generic search.'
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+          required: true
+          description: 'The term that should be searched for'
+      responses:
+        '200':
+          description: 'Returns a list of results'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adControllerPageInfo:
+                    $ref: '#/components/schemas/AdControllerPageInfo'
                   items:
-                    oneOf:
-                      - $ref: "#/components/schemas/CenterpageAdplace"
-                      - $ref: "#/components/schemas/CenterpageTeaser"
-                      - $ref: "#/components/schemas/CenterpageTeaserAuthor"
-                      - $ref: "#/components/schemas/CenterpageTeaserGallery"
-                      - $ref: "#/components/schemas/CenterpageTeaserVideo"
-                      - $ref: "#/components/schemas/CenterpageTeaserPodcast"
-                      - $ref: "#/components/schemas/CenterpageTeaserAudio"
-                      - $ref: "#/components/schemas/CenterpageModuleHTML"
-                    discriminator:
-                      propertyName: type
-                      mapping:
-                        adplace: "#/components/schemas/CenterpageAdplace"
-                        teaser: "#/components/schemas/CenterpageTeaser"
-                        teaser-author: "#/components/schemas/CenterpageTeaserAuthor"
-                        teaser-gallery: "#/components/schemas/CenterpageTeaserGallery"
-                        teaser-video: "#/components/schemas/CenterpageTeaserVideo"
-                        teaser-podcast: "#/components/schemas/CenterpageTeaserPodcast"
-                        teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
-                        html: "#/components/schemas/CenterpageModuleHTML"
-                trackingData:
-                  $ref: "#/components/schemas/TrackingData"
-      "400":
-        description: "Invalid query, see response body for details."
+                    type: array
+                    items:
+                      oneOf:
+                        - $ref: '#/components/schemas/CenterpageAdplace'
+                        - $ref: '#/components/schemas/CenterpageTeaser'
+                        - $ref: '#/components/schemas/CenterpageTeaserAuthor'
+                        - $ref: '#/components/schemas/CenterpageTeaserGallery'
+                        - $ref: '#/components/schemas/CenterpageTeaserVideo'
+                        - $ref: '#/components/schemas/CenterpageTeaserPodcast'
+                        - $ref: '#/components/schemas/CenterpageTeaserAudio'
+                        - $ref: '#/components/schemas/CenterpageModuleHTML'
+                      discriminator:
+                        propertyName: type
+                        mapping:
+                          adplace: '#/components/schemas/CenterpageAdplace'
+                          teaser: '#/components/schemas/CenterpageTeaser'
+                          teaser-author: '#/components/schemas/CenterpageTeaserAuthor'
+                          teaser-gallery: '#/components/schemas/CenterpageTeaserGallery'
+                          teaser-video: '#/components/schemas/CenterpageTeaserVideo'
+                          teaser-podcast: '#/components/schemas/CenterpageTeaserPodcast'
+                          teaser-audio: '#/components/schemas/CenterpageTeaserAudio'
+                          html: '#/components/schemas/CenterpageModuleHTML'
+                  trackingData:
+                    $ref: '#/components/schemas/TrackingData'
+        '400':
+          description: 'Invalid query, see response body for details.'
 
   /structure:
     get:
       tags:
         - structure
-      summary: "Returns tab and menu/submenu configuration for the app UI"
+      summary: 'Returns tab and menu/submenu configuration for the app UI'
       responses:
-        "200":
+        '200':
           # XXX description is required, but really already exists in ..summary
-          description: "Success"
+          description: 'Success'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Structure"
-              example: {tabs: [
-                {id: start, title: Start, type: tab-centerpage, icon: home, items: [
-                  {id: homepage, title: Aktuell, type: menu-item-web, url: "https://www.zeit.de/index"},
-                  {id: ressortPolitik, title: Politik, type: menu-item-native, source: "{urn:uuid:b4d1e3b1-aac4-4a80-b820-e4093fe24a36}"},
-                  {id: ressortGesellschaft, title: Gesellschaft, type: menu-item-native, source: "{urn:uuid:c92ad9be-67e0-497d-beee-6c2e063352cc}"},
-                  {id: ressortWirtschaft, title: Wirtschaft, type: menu-item-native, source: "{urn:uuid:ea13ef02-74f3-4010-8cd7-777327fb881a}"},
-                  {id: ressortWissen, title: Wissen, type: menu-item-native, source: "{urn:uuid:c84692ca-b0c9-4772-8c6b-85e2abc446e1}"},
-                  {id: ressortKultur, title: Kultur, type: menu-item-native, source: "{urn:uuid:49b109f0-bbad-495e-8a88-ad91ec1ef8f9}"}
-                ]},
-                {id: news, title: Schlagzeilen, type: tab-centerpage, icon: clock, items: [
-                  {id: newsAll, title: "Alle Schlagzeilen", type: menu-item-native, source: "{urn:uuid:08945d5e-483c-4e7b-9843-69a8f590ada9}"},
-                  {id: newsMostImportant, title: "Die wichtigsten Nachrichten", type: menu-item-native, source: "{urn:uuid:df60a52c-5f4d-4804-833d-ec31e24dbd43}"},
-                  {id: newsAnalysisAndReports, title: "Analysen und Hintergründe", type: menu-item-native, source: "{urn:uuid:d6913463-1804-466d-b6d0-34376ef21916}"}
-                ]},
-                {id: explore, title: Entdecken, type: tab-story, icon: compass, items: [
-                  {id: explore-all, title: Entdecken, type: menu-item-native, source: "{urn:uuid:99ae6607-fe0f-44ad-97fb-00dd0d852c30}"}
-                ]},
-                {id: zplus, title: Mein Abo, type: tab-centerpage, icon: zplus, items: [
-                  {id: exclusive, title: "Exklusive Artikel", type: menu-item-native, source: "{urn:uuid:0fd9480f-1b52-4fcb-942e-8089e378102e}"},
-                  {id: zeitPDFWebReader, title: "DIE ZEIT", type: menu-item-web, url: "https://epaper.zeit.de/abo/diezeit"},
-                  {id: wochenMarkt, title: "Wochenmarkt", type: menu-item-web, url: "https://www.zeit.de/wochenmarkt"}
-                ]},
-                {id: menu, title: Mehr, type: tab-menu, icon: avatar, items: [
-                  {id: user-menu, title: "Mein Bereich", items: [
-                    {id: reading-list, title: Merkliste, type: menu-item-app, targetId: native-reading-list},
-                    {id: reading-history, title: Verlauf, type: menu-item-app, targetId: native-reading-history},
-                    {id: comment-list, title: Kommentare, type: menu-item-web, url: "https://profile.zeit.de"}
-                  ]},
-                  {id: angebote, title: Angebote, items: [
-                    {id: anzeigen, title: Anzeigen, type: menu-item-submenu, items: [
-                      {id: ad1, title: Werbung, type: menu-item-web, url: "https://www.werbung.de"},
-                      {id: ad2, title: Anzeige, type: menu-item-web, url: "https://www.werbung.de"},
-                      {id: ad3, title: Promo, type: menu-item-web, url: "https://www.werbung.de"}
-                    ]}
-                  ]}
-                ]}
-              ]}
-        "400":
-          description: "Something was wrong with the request. Check the body for error messages."
+                $ref: '#/components/schemas/Structure'
+              example:
+                {
+                  tabs:
+                    [
+                      {
+                        id: start,
+                        title: Start,
+                        type: tab-centerpage,
+                        icon: home,
+                        items:
+                          [
+                            {
+                              id: homepage,
+                              title: Aktuell,
+                              type: menu-item-web,
+                              url: 'https://www.zeit.de/index',
+                            },
+                            {
+                              id: ressortPolitik,
+                              title: Politik,
+                              type: menu-item-native,
+                              source: '{urn:uuid:b4d1e3b1-aac4-4a80-b820-e4093fe24a36}',
+                            },
+                            {
+                              id: ressortGesellschaft,
+                              title: Gesellschaft,
+                              type: menu-item-native,
+                              source: '{urn:uuid:c92ad9be-67e0-497d-beee-6c2e063352cc}',
+                            },
+                            {
+                              id: ressortWirtschaft,
+                              title: Wirtschaft,
+                              type: menu-item-native,
+                              source: '{urn:uuid:ea13ef02-74f3-4010-8cd7-777327fb881a}',
+                            },
+                            {
+                              id: ressortWissen,
+                              title: Wissen,
+                              type: menu-item-native,
+                              source: '{urn:uuid:c84692ca-b0c9-4772-8c6b-85e2abc446e1}',
+                            },
+                            {
+                              id: ressortKultur,
+                              title: Kultur,
+                              type: menu-item-native,
+                              source: '{urn:uuid:49b109f0-bbad-495e-8a88-ad91ec1ef8f9}',
+                            },
+                          ],
+                      },
+                      {
+                        id: news,
+                        title: Schlagzeilen,
+                        type: tab-centerpage,
+                        icon: clock,
+                        items:
+                          [
+                            {
+                              id: newsAll,
+                              title: 'Alle Schlagzeilen',
+                              type: menu-item-native,
+                              source: '{urn:uuid:08945d5e-483c-4e7b-9843-69a8f590ada9}',
+                            },
+                            {
+                              id: newsMostImportant,
+                              title: 'Die wichtigsten Nachrichten',
+                              type: menu-item-native,
+                              source: '{urn:uuid:df60a52c-5f4d-4804-833d-ec31e24dbd43}',
+                            },
+                            {
+                              id: newsAnalysisAndReports,
+                              title: 'Analysen und Hintergründe',
+                              type: menu-item-native,
+                              source: '{urn:uuid:d6913463-1804-466d-b6d0-34376ef21916}',
+                            },
+                          ],
+                      },
+                      {
+                        id: explore,
+                        title: Entdecken,
+                        type: tab-story,
+                        icon: compass,
+                        items:
+                          [
+                            {
+                              id: explore-all,
+                              title: Entdecken,
+                              type: menu-item-native,
+                              source: '{urn:uuid:99ae6607-fe0f-44ad-97fb-00dd0d852c30}',
+                            },
+                          ],
+                      },
+                      {
+                        id: zplus,
+                        title: Mein Abo,
+                        type: tab-centerpage,
+                        icon: zplus,
+                        items:
+                          [
+                            {
+                              id: exclusive,
+                              title: 'Exklusive Artikel',
+                              type: menu-item-native,
+                              source: '{urn:uuid:0fd9480f-1b52-4fcb-942e-8089e378102e}',
+                            },
+                            {
+                              id: zeitPDFWebReader,
+                              title: 'DIE ZEIT',
+                              type: menu-item-web,
+                              url: 'https://epaper.zeit.de/abo/diezeit',
+                            },
+                            {
+                              id: wochenMarkt,
+                              title: 'Wochenmarkt',
+                              type: menu-item-web,
+                              url: 'https://www.zeit.de/wochenmarkt',
+                            },
+                          ],
+                      },
+                      {
+                        id: menu,
+                        title: Mehr,
+                        type: tab-menu,
+                        icon: avatar,
+                        items:
+                          [
+                            {
+                              id: user-menu,
+                              title: 'Mein Bereich',
+                              items:
+                                [
+                                  {
+                                    id: reading-list,
+                                    title: Merkliste,
+                                    type: menu-item-app,
+                                    targetId: native-reading-list,
+                                  },
+                                  {
+                                    id: reading-history,
+                                    title: Verlauf,
+                                    type: menu-item-app,
+                                    targetId: native-reading-history,
+                                  },
+                                  {
+                                    id: comment-list,
+                                    title: Kommentare,
+                                    type: menu-item-web,
+                                    url: 'https://profile.zeit.de',
+                                  },
+                                ],
+                            },
+                            {
+                              id: angebote,
+                              title: Angebote,
+                              items:
+                                [
+                                  {
+                                    id: anzeigen,
+                                    title: Anzeigen,
+                                    type: menu-item-submenu,
+                                    items:
+                                      [
+                                        {
+                                          id: ad1,
+                                          title: Werbung,
+                                          type: menu-item-web,
+                                          url: 'https://www.werbung.de',
+                                        },
+                                        {
+                                          id: ad2,
+                                          title: Anzeige,
+                                          type: menu-item-web,
+                                          url: 'https://www.werbung.de',
+                                        },
+                                        {
+                                          id: ad3,
+                                          title: Promo,
+                                          type: menu-item-web,
+                                          url: 'https://www.werbung.de',
+                                        },
+                                      ],
+                                  },
+                                ],
+                            },
+                          ],
+                      },
+                    ],
+                }
+        '400':
+          description: 'Something was wrong with the request. Check the body for error messages.'
 
   /user:
     get:
@@ -683,46 +829,42 @@ paths:
         - cookieAuthTesting: []
       tags:
         - user
-      summary: "Returns information about the current user"
+      summary: 'Returns information about the current user'
       responses:
-        "200":
-          description: "Information about the currently logged in user"
+        '200':
+          description: 'Information about the currently logged in user'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserInfo"
-        "400":
-          description: "Something was wrong with the request. Check the body for error messages."
-        "401":
-          description: "The user is not logged in"
+                $ref: '#/components/schemas/UserInfo'
+        '400':
+          description: 'Something was wrong with the request. Check the body for error messages.'
+        '401':
+          description: 'The user is not logged in'
 
 components:
   requestBodies:
     AppStoreReceipt:
       content:
-        "text/plain": {
-          "schema": {
-            "$ref": "#/components/schemas/AppStoreReceipt"
-          }
-        }
+        'text/plain': { 'schema': { '$ref': '#/components/schemas/AppStoreReceipt' } }
 
   schemas:
     UUID:
       type: string
       pattern: "^((\\{urn:uuid:)?([a-f0-9]{8})(-[a-f0-9]{4}){3}(-[a-f0-9]{12})\\}?|[-a-z0-9/]+)$"
-      description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
-      example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda} or d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda"
+      description: 'CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted.'
+      example: '{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda} or d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda'
 
     UUIDList:
       type: array
       items:
-        $ref: "#/components/schemas/UUID"
+        $ref: '#/components/schemas/UUID'
 
     uuidfilter:
       type: string
       pattern: ^[eq\.]+(([a-f0-9]{8})(-[a-f0-9]{4}){3}(-[a-f0-9]{12})\\}?|[-a-z0-9/]+)$
       description: Postgrest equal filter function
-      example: "eq.d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda"
+      example: 'eq.d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda'
 
     bookmark:
       type: array
@@ -732,12 +874,12 @@ components:
         properties:
           created:
             type: string
-            example: "2022-11-25T16:18:37.124812+00:00"
+            example: '2022-11-25T16:18:37.124812+00:00'
           ssoid:
             type: integer
             example: 42
           uuid:
-            $ref: "#/components/schemas/UUID"
+            $ref: '#/components/schemas/UUID'
         required:
           - created
           - ssoid
@@ -747,7 +889,7 @@ components:
     BookmarkIds:
       type: object
       items:
-        $ref: "#/components/schemas/UUIDList"
+        $ref: '#/components/schemas/UUIDList'
 
     ContentEntitlements:
       type: array
@@ -769,85 +911,85 @@ components:
           type: array
           items:
             oneOf:
-              - $ref: "#/components/schemas/TabCenterpage"
-              - $ref: "#/components/schemas/TabMenu"
-              - $ref: "#/components/schemas/TabStory"
+              - $ref: '#/components/schemas/TabCenterpage'
+              - $ref: '#/components/schemas/TabMenu'
+              - $ref: '#/components/schemas/TabStory'
             discriminator:
               propertyName: type
               mapping:
-                tab-centerpage: "#/components/schemas/TabCenterpage"
-                tab-menu: "#/components/schemas/TabMenu"
-                tab-story: "#/components/schemas/TabStory"
+                tab-centerpage: '#/components/schemas/TabCenterpage'
+                tab-menu: '#/components/schemas/TabMenu'
+                tab-story: '#/components/schemas/TabStory'
         menus:
           type: array
           items:
             oneOf:
-              - $ref: "#/components/schemas/ContentMenu"
-              - $ref: "#/components/schemas/UserMenu"
+              - $ref: '#/components/schemas/ContentMenu'
+              - $ref: '#/components/schemas/UserMenu'
             discriminator:
               propertyName: type
               mapping:
-                content-menu: "#/components/schemas/ContentMenu"
-                user-menu: "#/components/schemas/UserMenu"
+                content-menu: '#/components/schemas/ContentMenu'
+                user-menu: '#/components/schemas/UserMenu'
 
     Centerpage:
       type: object
       properties:
         id:
-          $ref: "#/components/schemas/UUID"
+          $ref: '#/components/schemas/UUID'
         url:
           type: string
           # format: uri  XXX only supported in openapi-3.1
-          description: "Web URL for this CenterPage"
-          example: "https://www.zeit.de/politik/index"
+          description: 'Web URL for this CenterPage'
+          example: 'https://www.zeit.de/politik/index'
         pagetitle:
           type: string
         bookmarkable:
           type: boolean
           example: true
         adControllerPageInfo:
-          $ref: "#/components/schemas/AdControllerPageInfo"
+          $ref: '#/components/schemas/AdControllerPageInfo'
         trackingData:
-          $ref: "#/components/schemas/TrackingData"
+          $ref: '#/components/schemas/TrackingData'
         items:
           type: array
           items:
             oneOf:
-              - $ref: "#/components/schemas/CenterpageRegion"
-              - $ref: "#/components/schemas/CenterpageArea"
-              - $ref: "#/components/schemas/CenterpageTeaser"
-              - $ref: "#/components/schemas/CenterpageTeaserAuthor"
-              - $ref: "#/components/schemas/CenterpageTeaserGallery"
-              - $ref: "#/components/schemas/CenterpageTeaserVideo"
-              - $ref: "#/components/schemas/CenterpageTeaserPodcast"
-              - $ref: "#/components/schemas/CenterpageTeaserAudio"
-              - $ref: "#/components/schemas/CenterpageModuleHTML"
-              - $ref: "#/components/schemas/CenterpageAdplace"
-              - $ref: "#/components/schemas/CenterpageHeader"
-              - $ref: "#/components/schemas/CenterpageMarkup"
-              - $ref: "#/components/schemas/CenterpageExtra"
+              - $ref: '#/components/schemas/CenterpageRegion'
+              - $ref: '#/components/schemas/CenterpageArea'
+              - $ref: '#/components/schemas/CenterpageTeaser'
+              - $ref: '#/components/schemas/CenterpageTeaserAuthor'
+              - $ref: '#/components/schemas/CenterpageTeaserGallery'
+              - $ref: '#/components/schemas/CenterpageTeaserVideo'
+              - $ref: '#/components/schemas/CenterpageTeaserPodcast'
+              - $ref: '#/components/schemas/CenterpageTeaserAudio'
+              - $ref: '#/components/schemas/CenterpageModuleHTML'
+              - $ref: '#/components/schemas/CenterpageAdplace'
+              - $ref: '#/components/schemas/CenterpageHeader'
+              - $ref: '#/components/schemas/CenterpageMarkup'
+              - $ref: '#/components/schemas/CenterpageExtra'
             discriminator:
               propertyName: type
               mapping:
-                region: "#/components/schemas/CenterpageRegion"
-                area: "#/components/schemas/CenterpageArea"
-                teaser: "#/components/schemas/CenterpageTeaser"
-                teaser-author: "#/components/schemas/CenterpageTeaserAuthor"
-                teaser-gallery: "#/components/schemas/CenterpageTeaserGallery"
-                teaser-video: "#/components/schemas/CenterpageTeaserVideo"
-                teaser-podcast: "#/components/schemas/CenterpageTeaserPodcast"
-                teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
-                html: "#/components/schemas/CenterpageModuleHTML"
-                adplace: "#/components/schemas/CenterpageAdplace"
-                header: "#/components/schemas/CenterpageHeader"
-                markup: "#/components/schemas/CenterpageMarkup"
-                cpextra: "#/components/schemas/CenterpageExtra"
+                region: '#/components/schemas/CenterpageRegion'
+                area: '#/components/schemas/CenterpageArea'
+                teaser: '#/components/schemas/CenterpageTeaser'
+                teaser-author: '#/components/schemas/CenterpageTeaserAuthor'
+                teaser-gallery: '#/components/schemas/CenterpageTeaserGallery'
+                teaser-video: '#/components/schemas/CenterpageTeaserVideo'
+                teaser-podcast: '#/components/schemas/CenterpageTeaserPodcast'
+                teaser-audio: '#/components/schemas/CenterpageTeaserAudio'
+                html: '#/components/schemas/CenterpageModuleHTML'
+                adplace: '#/components/schemas/CenterpageAdplace'
+                header: '#/components/schemas/CenterpageHeader'
+                markup: '#/components/schemas/CenterpageMarkup'
+                cpextra: '#/components/schemas/CenterpageExtra'
 
     CenterpageElementId:
       type: string
-      pattern: "^id-[-a-f0-9]+$"
-      description: "ID of the cp element"
-      example: "id-fcfd3deb-4c26-472b-8bdd-238372d5131b"
+      pattern: '^id-[-a-f0-9]+$'
+      description: 'ID of the cp element'
+      example: 'id-fcfd3deb-4c26-472b-8bdd-238372d5131b'
 
     CenterpageElementType:
       type: string
@@ -865,7 +1007,7 @@ components:
         - header
         - markup
         - cpextra
-      description: "Type of the cp element"
+      description: 'Type of the cp element'
 
     AdControllerPageInfo:
       type: object
@@ -873,25 +1015,25 @@ components:
         doc:
           type: string
           nullable: true
-          description: "page type"
+          description: 'page type'
           enum:
             - homepage
             - index
             - artikel
             - bildgal
             - null
-          example: "index"
+          example: 'index'
         level2:
-          description: "Level2 property ressort for adplacement"
+          description: 'Level2 property ressort for adplacement'
           type: string
-          example: "politik"
+          example: 'politik'
         level3:
-          description: "Level3 property subressort, name of podcast or series for adplacement"
+          description: 'Level3 property subressort, name of podcast or series for adplacement'
           type: string
-          example: "deutschland"
+          example: 'deutschland'
         keywords:
           type: string
-          example: "zeitonline,coronavirus,frankreich,lockdown"
+          example: 'zeitonline,coronavirus,frankreich,lockdown'
 
     Image:
       type: object
@@ -900,7 +1042,7 @@ components:
         baseUrl:
           type: string
           # format: uri
-          example: "https://img.zeit.de/2020-08/flightradar-4"
+          example: 'https://img.zeit.de/2020-08/flightradar-4'
           description: |
             The URL is a base URL, which needs to be modified with the following query parameters in order to produce an actual image:
 
@@ -928,7 +1070,7 @@ components:
         fillColor:
           type: string
           nullable: true
-          example: "8ed8a6"
+          example: '8ed8a6'
         visibleMobile:
           type: boolean
           example: false
@@ -938,148 +1080,148 @@ components:
       properties:
         contentId:
           type: string
-          description: "Content-ID containing [Unit].[Ressort].[Subressort].[Cluster].[Pagetype].[Sourcetype]|[URL without protocol]"
-          example: "redaktion.politik.deutschland..centerpage.zede|www.zeit.de/politik/deutschland/index"
+          description: 'Content-ID containing [Unit].[Ressort].[Subressort].[Cluster].[Pagetype].[Sourcetype]|[URL without protocol]'
+          example: 'redaktion.politik.deutschland..centerpage.zede|www.zeit.de/politik/deutschland/index'
         contentGroup:
-          $ref: "#/components/schemas/TrackingContentGroup"
+          $ref: '#/components/schemas/TrackingContentGroup'
         customParameter:
-          $ref: "#/components/schemas/TrackingCustomParameter"
+          $ref: '#/components/schemas/TrackingCustomParameter'
 
     TrackingContentGroup:
       type: object
-      description: "Content groups for aggregation"
+      description: 'Content groups for aggregation'
       properties:
         1:
           type: string
-          description: "Unit"
-          example: "redaktion"
+          description: 'Unit'
+          example: 'redaktion'
         2:
           type: string
-          description: "Pagetype"
-          example: "centerpage"
+          description: 'Pagetype'
+          example: 'centerpage'
         3:
           type: string
-          description: "Ressort"
-          example: "politik"
+          description: 'Ressort'
+          example: 'politik'
         4:
           type: string
-          description: "Sourcetype"
-          example: "zede"
+          description: 'Sourcetype'
+          example: 'zede'
         5:
           type: string
-          description: "Subressort"
-          example: "deutschland"
+          description: 'Subressort'
+          example: 'deutschland'
         6:
           type: string
-          description: "Cluster (series name)"
-          example: "allesgesagt?"
+          description: 'Cluster (series name)'
+          example: 'allesgesagt?'
         7:
           type: string
-          description: "Basename"
-          example: "index"
+          description: 'Basename'
+          example: 'index'
         8:
           type: string
-          description: "Banner-Channel"
-          example: "politik/deutschland/centerpage"
+          description: 'Banner-Channel'
+          example: 'politik/deutschland/centerpage'
         9:
           type: string
-          description: "Date first released"
-          example: "2019-06-12"
+          description: 'Date first released'
+          example: '2019-06-12'
 
     TrackingCustomParameter:
       type: object
-      description: "Custom page parameter"
+      description: 'Custom page parameter'
       properties:
         2:
           type: string
-          description: "IVW-Code"
-          example: "politik/deutschland/bild-text"
+          description: 'IVW-Code'
+          example: 'politik/deutschland/bild-text'
         3:
           type: string
-          description: "Pagination"
-          example: "1/1"
+          description: 'Pagination'
+          example: '1/1'
         4:
           type: string
-          description: "Keywords separated by semicolons"
-          example: "politik;deutschland"
+          description: 'Keywords separated by semicolons'
+          example: 'politik;deutschland'
         5:
           type: string
-          description: "Date last published"
-          example: "2019-06-12 15:21:44.350769+02:00"
+          description: 'Date last published'
+          example: '2019-06-12 15:21:44.350769+02:00'
         8:
           type: string
-          description: "Product-ID"
-          example: "zede"
+          description: 'Product-ID'
+          example: 'zede'
         9:
           type: string
-          description: "Banner-Channel"
-          example: "politik/deutschland/centerpage"
+          description: 'Banner-Channel'
+          example: 'politik/deutschland/centerpage'
         10:
           type: string
-          description: "Banner active (advertising enabled)"
+          description: 'Banner active (advertising enabled)'
           enum:
-            - "yes"
-            - "no"
-          example: "yes"
+            - 'yes'
+            - 'no'
+          example: 'yes'
         25:
           type: string
-          description: "Plattform"
-          example: "original"
+          description: 'Plattform'
+          example: 'original'
         26:
           type: string
-          description: "Detailed Content-Type"
-          example: "centerpage.centerpage"
+          description: 'Detailed Content-Type'
+          example: 'centerpage.centerpage'
         28:
           type: string
-          description: "Access"
+          description: 'Access'
           enum:
             - free
             - registration
             - dynamic
             - abo
-          example: "free"
+          example: 'free'
         29:
           type: string
-          description: "First Click Free"
+          description: 'First Click Free'
           enum:
-            - "yes"
-            - "no"
+            - 'yes'
+            - 'no'
             - unfeasible
-          example: "unfeasible"
+          example: 'unfeasible'
         30:
           type: string
-          description: "Paywall Status"
+          description: 'Paywall Status'
           enum:
             - open
             - register
             - metered
             - paid
-          example: "open"
+          example: 'open'
         38:
           type: string
-          description: "Channels separated by semicolons"
-          example: "podcast;kultur;film"
+          description: 'Channels separated by semicolons'
+          example: 'podcast;kultur;film'
 
     CustomClickParameter:
       type: object
-      description: "Custom click parameter"
+      description: 'Custom click parameter'
       properties:
         5:
           type: string
-          description: "Area"
-          example: "headed-zplus"
+          description: 'Area'
+          example: 'headed-zplus'
         6:
           type: string
-          description: "Row"
-          example: "1"
+          description: 'Row'
+          example: '1'
         7:
           type: string
-          description: "Column"
-          example: "4"
+          description: 'Column'
+          example: '4'
         8:
           type: string
-          description: "Subcolumn"
-          example: "zon-teaser-standard"
+          description: 'Subcolumn'
+          example: 'zon-teaser-standard'
 
     AudioConnection:
       type: object
@@ -1095,7 +1237,7 @@ components:
         url:
           type: string
           # format: uri
-          example: "https://podcasts.apple.com/podcast/id1279335230"
+          example: 'https://podcasts.apple.com/podcast/id1279335230'
 
     Audio:
       type: object
@@ -1108,37 +1250,37 @@ components:
         audioType:
           type: string
           enum: [custom, podcast, premium, tts]
-          description: "type of audio source"
+          description: 'type of audio source'
         access:
           type: string
           nullable: true
           enum: [abo, registration, dynamic, null]
-          description: "DEPRECATED use `entitlements` instead"
+          description: 'DEPRECATED use `entitlements` instead'
         entitlements:
-          $ref: "#/components/schemas/ContentEntitlements"
+          $ref: '#/components/schemas/ContentEntitlements'
         color:
           type: string
           nullable: true
-          example: "8ed8a6"
+          example: '8ed8a6'
         duration:
           type: integer
           nullable: true
-          description: "total duration of the audio in seconds"
+          description: 'total duration of the audio in seconds'
         url:
           type: string
           # format: uri
-          description: "URL directly to the audio source"
-          example: "https://injector.simplecastaudio.com/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/128/default.mp3?awCollectionId=60989a9e-80b6-4f17-979a-fc949043cf6b&amp;awEpisodeId=0d4af84d-a3b9-4373-8c99-c20fe3c16345"
+          description: 'URL directly to the audio source'
+          example: 'https://injector.simplecastaudio.com/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/128/default.mp3?awCollectionId=60989a9e-80b6-4f17-979a-fc949043cf6b&amp;awEpisodeId=0d4af84d-a3b9-4373-8c99-c20fe3c16345'
         ad-free-url:
           type: string
           nullable: true
           # format: uri
-          description: "Adfree URL directly to the audio source"
-          example: "https://cdn.simplecast.com/audio/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/16a0ad94-096b-42b6-b7a2-c02f15fe9085/default_tc.mp3"
+          description: 'Adfree URL directly to the audio source'
+          example: 'https://cdn.simplecast.com/audio/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/16a0ad94-096b-42b6-b7a2-c02f15fe9085/default_tc.mp3'
 
     PodcastAudio:
       type: object
-      description: "Legacy audio object for CenterpageTeaserPodcast"
+      description: 'Legacy audio object for CenterpageTeaserPodcast'
       nullable: true
       required:
         - duration
@@ -1147,25 +1289,25 @@ components:
         color:
           type: string
           nullable: true
-          example: "8ed8a6"
+          example: '8ed8a6'
         duration:
           type: string
-          example: "-00:05:23"
+          example: '-00:05:23'
         url:
           type: string
           # format: uri
-          description: "URL directly to the audio source"
-          example: "https://injector.simplecastaudio.com/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/128/default.mp3?awCollectionId=60989a9e-80b6-4f17-979a-fc949043cf6b&amp;awEpisodeId=0d4af84d-a3b9-4373-8c99-c20fe3c16345"
+          description: 'URL directly to the audio source'
+          example: 'https://injector.simplecastaudio.com/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/128/default.mp3?awCollectionId=60989a9e-80b6-4f17-979a-fc949043cf6b&amp;awEpisodeId=0d4af84d-a3b9-4373-8c99-c20fe3c16345'
         ad-free-url:
           type: string
           nullable: true
           # format: uri
-          description: "Adfree URL directly to the audio source"
-          example: "https://cdn.simplecast.com/audio/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/16a0ad94-096b-42b6-b7a2-c02f15fe9085/default_tc.mp3"
+          description: 'Adfree URL directly to the audio source'
+          example: 'https://cdn.simplecast.com/audio/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/16a0ad94-096b-42b6-b7a2-c02f15fe9085/default_tc.mp3'
         connections:
           type: array
           items:
-            $ref: "#/components/schemas/AudioConnection"
+            $ref: '#/components/schemas/AudioConnection'
 
     Volume:
       type: object
@@ -1176,15 +1318,15 @@ components:
         - number
       properties:
         volumeImage:
-          $ref: "#/components/schemas/Image"
+          $ref: '#/components/schemas/Image'
         volumeLabel:
           type: string
-          description: "label for for volume"
-          example: "DIE ZEIT 12/2023"
+          description: 'label for for volume'
+          example: 'DIE ZEIT 12/2023'
         volumeColor:
           type: string
-          description: "Hex value of background color of the volume without #"
-          example: "2e8b57"
+          description: 'Hex value of background color of the volume without #'
+          example: '2e8b57'
           minLength: 6
           maxLength: 6
           nullable: true
@@ -1192,30 +1334,30 @@ components:
           type: string
           nullable: true
           # format: uri
-          description: "An URL to the volume"
-          example: "https://www.zeit.de/2023/12/index"
+          description: 'An URL to the volume'
+          example: 'https://www.zeit.de/2023/12/index'
         year:
           type: integer
         number:
           type: integer
         datePublished:
           type: string
-          description: "Formatted date of publication"
-          example: "25. Januar 2024"
+          description: 'Formatted date of publication'
+          example: '25. Januar 2024'
 
     CenterpageElement:
       required:
         - type
       properties:
         id:
-          $ref: "#/components/schemas/CenterpageElementId"
+          $ref: '#/components/schemas/CenterpageElementId'
         type:
-          $ref: "#/components/schemas/CenterpageElementType"
+          $ref: '#/components/schemas/CenterpageElementType'
 
     CenterpageTeaserBase:
-      description: "A teaser module references/represents a content object (article, video, etc.)"
+      description: 'A teaser module references/represents a content object (article, video, etc.)'
       allOf:
-        - $ref: "#/components/schemas/CenterpageElement"
+        - $ref: '#/components/schemas/CenterpageElement'
         - required:
             - layout
             - title
@@ -1257,53 +1399,53 @@ components:
                 - zon-teaser-standard-compact
                 - zon-teaser-stripe
                 - zon-teaser-wide
-              description: "How to display this teaser (e.g large/small)"
+              description: 'How to display this teaser (e.g large/small)'
             title:
               type: string
-              description: "Main title of the article"
-              example: "My Article Title"
+              description: 'Main title of the article'
+              example: 'My Article Title'
             supertitle:
               type: string
               nullable: true
-              description: "The supertitle/kicker are 1-2 keywords that denote the context/topic of the article"
-              example: "Olympics"
+              description: 'The supertitle/kicker are 1-2 keywords that denote the context/topic of the article'
+              example: 'Olympics'
             text:
               type: string
               nullable: true
-              description: "Teaser text is a few sentences that summarize/introduce the article"
+              description: 'Teaser text is a few sentences that summarize/introduce the article'
               example: "This is the teaser text\nIt may contain line breaks."
             url:
               type: string
               # format: uri
-              example: "https://www.zeit.de/my/article"
+              example: 'https://www.zeit.de/my/article'
             uuid:
-              $ref: "#/components/schemas/UUID"
+              $ref: '#/components/schemas/UUID'
             image:
-              $ref: "#/components/schemas/Image"
+              $ref: '#/components/schemas/Image'
             authorImage:
-              $ref: "#/components/schemas/Image"
+              $ref: '#/components/schemas/Image'
             dateFirstPublished:
               type: string
               format: date-time
-              description: "Timestamp when the article was published initially"
-              example: "2019-12-31T13:12:00Z"
+              description: 'Timestamp when the article was published initially'
+              example: '2019-12-31T13:12:00Z'
             dateLastPublishedSemantic:
               type: string
               format: date-time
-              description: "Timestamp of the most recent semantic/relevant update to the article"
-              example: "2020-01-01T13:12:00Z"
+              description: 'Timestamp of the most recent semantic/relevant update to the article'
+              example: '2020-01-01T13:12:00Z'
             date:
               type: string
               nullable: true
-              description: "Human readable relative or absolute date"
-              example: "Vor 3 Stunden"
+              description: 'Human readable relative or absolute date'
+              example: 'Vor 3 Stunden'
             entitlements:
-              $ref: "#/components/schemas/ContentEntitlements"
+              $ref: '#/components/schemas/ContentEntitlements'
             byline:
               type: string
               nullable: true
-              description: "Ready-made string that contains the author names and maybe some more information like the article genre"
-              example: "Eine Glosse von August Weythershaußen, Erzgebirge"
+              description: 'Ready-made string that contains the author names and maybe some more information like the article genre'
+              example: 'Eine Glosse von August Weythershaußen, Erzgebirge'
             badges:
               type: array
               items:
@@ -1313,36 +1455,36 @@ components:
                   - livestream
                   - zplus
                   - zplus-spiele
-              description: "List of icon IDs that should be displayed for this teaser"
-              example: ["zplus"]
+              description: 'List of icon IDs that should be displayed for this teaser'
+              example: ['zplus']
             label:
               type: string
               # ZON-6127: disabled until the implementation catches up:
               # enum:
               #   - Anzeige
               #   - Verlagsangebot
-              description: "Additional label to mark teasers with corporate advertising"
-              example: "Verlagsangebot"
+              description: 'Additional label to mark teasers with corporate advertising'
+              example: 'Verlagsangebot'
             audioInfo:
-              $ref: "#/components/schemas/Audio"
+              $ref: '#/components/schemas/Audio'
             volume:
-              $ref: "#/components/schemas/Volume"
+              $ref: '#/components/schemas/Volume'
             comments:
               type: object
               properties:
                 count:
                   type: string
-                  description: "Count of comments for this article"
-                  example: "18.345"
+                  description: 'Count of comments for this article'
+                  example: '18.345'
                 label:
                   type: string
-                  description: "Descriptive label for count of comments for this article"
-                  example: "18.345 Kommentare"
+                  description: 'Descriptive label for count of comments for this article'
+                  example: '18.345 Kommentare'
                 url:
                   type: string
                   # format: uri
-                  description: "URL directly to the comment area of the article"
-                  example: "https://www.zeit.de/my/article#comments"
+                  description: 'URL directly to the comment area of the article'
+                  example: 'https://www.zeit.de/my/article#comments'
             bookmarkable:
               type: boolean
               example: true
@@ -1350,7 +1492,7 @@ components:
               type: object
               properties:
                 customClickParameter:
-                  $ref: "#/components/schemas/CustomClickParameter"
+                  $ref: '#/components/schemas/CustomClickParameter'
             liveblogPosts:
               nullable: true
               type: array
@@ -1359,34 +1501,34 @@ components:
                 properties:
                   title:
                     type: string
-                    description: "Title of the liveblog entry"
-                    example: "Ereignisse haben stattgefunden"
+                    description: 'Title of the liveblog entry'
+                    example: 'Ereignisse haben stattgefunden'
                   url:
                     type: string
                     # format: uri
-                    description: "URL directly to the liveblog entry"
-                    example: "https://www.zeit.de/politik/ausland/2023-12/news-live#tickaroo_event_id=xxx"
+                    description: 'URL directly to the liveblog entry'
+                    example: 'https://www.zeit.de/politik/ausland/2023-12/news-live#tickaroo_event_id=xxx'
                   date:
                     type: string
-                    description: "A nice description of the datetime the liveblog entry was posted"
-                    example: "Gestern, 16:45 Uhr"
-              description: "List of liveblog posts that should be displayed for this teaser"
+                    description: 'A nice description of the datetime the liveblog entry was posted'
+                    example: 'Gestern, 16:45 Uhr'
+              description: 'List of liveblog posts that should be displayed for this teaser'
 
     CenterpageTeaser:
-      description: "A teaser module references/represents an article content object"
+      description: 'A teaser module references/represents an article content object'
       allOf:
-        - $ref: "#/components/schemas/CenterpageTeaserBase"
+        - $ref: '#/components/schemas/CenterpageTeaserBase'
         - properties:
             type:
               type: string
               enum:
                 - teaser
-              example: "teaser"
+              example: 'teaser'
 
     CenterpageTeaserGallery:
-      description: "A teaser module references/represents a gallery content object"
+      description: 'A teaser module references/represents a gallery content object'
       allOf:
-        - $ref: "#/components/schemas/CenterpageTeaserBase"
+        - $ref: '#/components/schemas/CenterpageTeaserBase'
         - required:
             - gallery
           properties:
@@ -1394,19 +1536,19 @@ components:
               type: string
               enum:
                 - teaser-gallery
-              example: "teaser-gallery"
+              example: 'teaser-gallery'
             gallery:
               type: object
               properties:
                 label:
                   type: string
-                  description: "Label to display gallery content"
-                  example: "18 Bilder"
+                  description: 'Label to display gallery content'
+                  example: '18 Bilder'
 
     CenterpageTeaserVideo:
-      description: "A teaser module references/represents a video content object"
+      description: 'A teaser module references/represents a video content object'
       allOf:
-        - $ref: "#/components/schemas/CenterpageTeaserBase"
+        - $ref: '#/components/schemas/CenterpageTeaserBase'
         - required:
             - video
           properties:
@@ -1414,13 +1556,13 @@ components:
               type: string
               enum:
                 - teaser-video
-              example: "teaser-video"
+              example: 'teaser-video'
             video:
               type: object
               properties:
                 id:
                   type: string
-                  example: "6194436097001"
+                  example: '6194436097001'
                 hasAdvertisement:
                   type: boolean
                 # provider: "brightcove"
@@ -1429,9 +1571,9 @@ components:
                 # series: serienname
 
     CenterpageTeaserPodcast:
-      description: "A teaser module references/represents an article content object with audio (simplecast podcast)"
+      description: 'A teaser module references/represents an article content object with audio (simplecast podcast)'
       allOf:
-        - $ref: "#/components/schemas/CenterpageTeaserBase"
+        - $ref: '#/components/schemas/CenterpageTeaserBase'
         - required:
             - audio
             - audioInfo
@@ -1440,24 +1582,24 @@ components:
               type: string
               enum:
                 - teaser-podcast
-              example: "teaser-podcast"
+              example: 'teaser-podcast'
             audio:
-              $ref: "#/components/schemas/PodcastAudio"
+              $ref: '#/components/schemas/PodcastAudio'
             audioInfo:
-              $ref: "#/components/schemas/Audio"
+              $ref: '#/components/schemas/Audio'
             episodeImage:
-              $ref: "#/components/schemas/Image"
+              $ref: '#/components/schemas/Image'
             seriesImage:
-              $ref: "#/components/schemas/Image"
+              $ref: '#/components/schemas/Image'
             seriesUrl:
               type: string
-              example: "https://www.zeit.de/serie/alles-gesagt"
-              description: "An URL to the series if podcast is episode of it"
+              example: 'https://www.zeit.de/serie/alles-gesagt'
+              description: 'An URL to the series if podcast is episode of it'
 
     CenterpageTeaserAudio:
-      description: "A teaser module references/represents an article content object with premium audio"
+      description: 'A teaser module references/represents an article content object with premium audio'
       allOf:
-        - $ref: "#/components/schemas/CenterpageTeaserBase"
+        - $ref: '#/components/schemas/CenterpageTeaserBase'
         - required:
             - audioInfo
           properties:
@@ -1465,16 +1607,16 @@ components:
               type: string
               enum:
                 - teaser-audio
-              example: "teaser-audio"
+              example: 'teaser-audio'
             audioInfo:
-              $ref: "#/components/schemas/Audio"
+              $ref: '#/components/schemas/Audio'
             volume:
-              $ref: "#/components/schemas/Volume"
+              $ref: '#/components/schemas/Volume'
 
     CenterpageModuleHTML:
-      description: "A non-native module that should be displayed via a web view"
+      description: 'A non-native module that should be displayed via a web view'
       allOf:
-        - $ref: "#/components/schemas/CenterpageElement"
+        - $ref: '#/components/schemas/CenterpageElement'
         - required:
             - content
           properties:
@@ -1482,16 +1624,16 @@ components:
               type: string
               enum:
                 - html
-              example: "html"
+              example: 'html'
             content:
               type: string
               format: html
-              example: "<embed>Anything can happen here.</embed>"
+              example: '<embed>Anything can happen here.</embed>'
 
     CenterpageTeaserAuthor:
-      description: "A teaser module references/represents an author content object"
+      description: 'A teaser module references/represents an author content object'
       allOf:
-        - $ref: "#/components/schemas/CenterpageTeaserBase"
+        - $ref: '#/components/schemas/CenterpageTeaserBase'
         - properties:
             type:
               type: string
@@ -1499,9 +1641,9 @@ components:
                 - teaser-author
 
     CenterpageAreaBase:
-      description: "CenterPages contain areas, which in turn contain modules"
+      description: 'CenterPages contain areas, which in turn contain modules'
       allOf:
-        - $ref: "#/components/schemas/CenterpageElement"
+        - $ref: '#/components/schemas/CenterpageElement'
         - required:
             - layout
             - items
@@ -1512,33 +1654,33 @@ components:
               type: string
               nullable: true
               # format: uri
-              description: "A section often links to topic pages etc."
-              example: "https://www.zeit.de/thema/hamburg"
+              description: 'A section often links to topic pages etc.'
+              example: 'https://www.zeit.de/thema/hamburg'
             linkedUuid:
-              $ref: "#/components/schemas/UUID"
-              description: "The UUID of the link, if given"
-              example: "977ff669-b044-4a1b-b444-00c1d717905f"
+              $ref: '#/components/schemas/UUID'
+              description: 'The UUID of the link, if given'
+              example: '977ff669-b044-4a1b-b444-00c1d717905f'
             title:
               type: string
               nullable: true
-              example: "This is a simple title"
+              example: 'This is a simple title'
             supertitle:
               type: string
               nullable: true
-              example: "Das Beste aus Z+"
+              example: 'Das Beste aus Z+'
             items:
               type: array
             topiclinks:
               nullable: true
               items:
-                $ref: "#/components/schemas/CenterpageAreaTopicLink"
+                $ref: '#/components/schemas/CenterpageAreaTopicLink'
             readmore:
               type: string
               nullable: true
-              example: "Mehr zum Thema Simple Title"
+              example: 'Mehr zum Thema Simple Title'
 
     CenterpageAreaTopicLink:
-      description: "Links to topicpage"
+      description: 'Links to topicpage'
       type: object
       required:
         - label
@@ -1546,20 +1688,20 @@ components:
       properties:
         label:
           type: string
-          example: "Hongkong"
+          example: 'Hongkong'
         link:
           type: string
           example: https://www.zeit.de/schlagworte/orte/hongkong/index"
 
     CenterpageRegion:
       allOf:
-        - $ref: "#/components/schemas/CenterpageAreaBase"
+        - $ref: '#/components/schemas/CenterpageAreaBase'
         - properties:
             type:
               type: string
               enum:
                 - region
-              example: "region"
+              example: 'region'
             layout:
               type: string
               enum:
@@ -1570,17 +1712,17 @@ components:
             items:
               type: array
               items:
-                $ref: "#/components/schemas/CenterpageArea"
+                $ref: '#/components/schemas/CenterpageArea'
 
     CenterpageArea:
       allOf:
-        - $ref: "#/components/schemas/CenterpageAreaBase"
+        - $ref: '#/components/schemas/CenterpageAreaBase'
         - properties:
             type:
               type: string
               enum:
                 - area
-              example: "area"
+              example: 'area'
             layout:
               type: string
               enum:
@@ -1604,63 +1746,63 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: "#/components/schemas/CenterpageTeaser"
-                  - $ref: "#/components/schemas/CenterpageTeaserAuthor"
-                  - $ref: "#/components/schemas/CenterpageTeaserGallery"
-                  - $ref: "#/components/schemas/CenterpageTeaserVideo"
-                  - $ref: "#/components/schemas/CenterpageTeaserPodcast"
-                  - $ref: "#/components/schemas/CenterpageTeaserAudio"
-                  - $ref: "#/components/schemas/CenterpageModuleHTML"
-                  - $ref: "#/components/schemas/CenterpageExtra"
+                  - $ref: '#/components/schemas/CenterpageTeaser'
+                  - $ref: '#/components/schemas/CenterpageTeaserAuthor'
+                  - $ref: '#/components/schemas/CenterpageTeaserGallery'
+                  - $ref: '#/components/schemas/CenterpageTeaserVideo'
+                  - $ref: '#/components/schemas/CenterpageTeaserPodcast'
+                  - $ref: '#/components/schemas/CenterpageTeaserAudio'
+                  - $ref: '#/components/schemas/CenterpageModuleHTML'
+                  - $ref: '#/components/schemas/CenterpageExtra'
                 discriminator:
                   propertyName: type
                   mapping:
-                    teaser: "#/components/schemas/CenterpageTeaser"
-                    teaser-author: "#/components/schemas/CenterpageTeaserAuthor"
-                    teaser-gallery: "#/components/schemas/CenterpageTeaserGallery"
-                    teaser-video: "#/components/schemas/CenterpageTeaserVideo"
-                    teaser-podcast: "#/components/schemas/CenterpageTeaserPodcast"
-                    teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
-                    html: "#/components/schemas/CenterpageModuleHTML"
-                    cpextra: "#/components/schemas/CenterpageExtra"
+                    teaser: '#/components/schemas/CenterpageTeaser'
+                    teaser-author: '#/components/schemas/CenterpageTeaserAuthor'
+                    teaser-gallery: '#/components/schemas/CenterpageTeaserGallery'
+                    teaser-video: '#/components/schemas/CenterpageTeaserVideo'
+                    teaser-podcast: '#/components/schemas/CenterpageTeaserPodcast'
+                    teaser-audio: '#/components/schemas/CenterpageTeaserAudio'
+                    html: '#/components/schemas/CenterpageModuleHTML'
+                    cpextra: '#/components/schemas/CenterpageExtra'
             trackingData:
               type: object
               properties:
                 customClickParameter:
-                  $ref: "#/components/schemas/CustomClickParameter"
+                  $ref: '#/components/schemas/CustomClickParameter'
 
     CenterpageAdplace:
-      description: "Placeholder for advertisement"
+      description: 'Placeholder for advertisement'
       required:
         - device
         - tile
       properties:
-          type:
-            type: string
-            enum:
-              - adplace
-          tile:
-            description: "IQD ad tile number"
-            type: string
-          device:
-            type: string
-            enum:
-              - desktop
-              - mobile
+        type:
+          type: string
+          enum:
+            - adplace
+        tile:
+          description: 'IQD ad tile number'
+          type: string
+        device:
+          type: string
+          enum:
+            - desktop
+            - mobile
 
     CenterpageHeader:
-      description: "Header for native centerpages"
+      description: 'Header for native centerpages'
       required:
         - type
       properties:
         id:
-          $ref: "#/components/schemas/CenterpageElementId"
+          $ref: '#/components/schemas/CenterpageElementId'
         type:
           type: string
           enum:
             - header
         image:
-          $ref: "#/components/schemas/Image"
+          $ref: '#/components/schemas/Image'
         supertitle:
           type: string
           nullable: true
@@ -1669,13 +1811,13 @@ components:
           nullable: true
 
     CenterpageMarkup:
-      description: "A list of text"
+      description: 'A list of text'
       required:
         - type
         - text
       properties:
         id:
-          $ref: "#/components/schemas/CenterpageElementId"
+          $ref: '#/components/schemas/CenterpageElementId'
         type:
           type: string
           enum:
@@ -1686,19 +1828,19 @@ components:
           type: string
 
     CenterpageExtra:
-      description: "CPExtra: additional content block for centerpages that can contain anything"
+      description: 'CPExtra: additional content block for centerpages that can contain anything'
       required:
         - type
         - cpextra
       properties:
         id:
-          $ref: "#/components/schemas/CenterpageElementId"
+          $ref: '#/components/schemas/CenterpageElementId'
         type:
           type: string
           enum:
             - cpextra
         cpextra:
-          description: "The content type this CPExtra represents"
+          description: 'The content type this CPExtra represents'
           type: string
 
     TabBase:
@@ -1711,13 +1853,13 @@ components:
       properties:
         id:
           type: string
-          description: "ID of the tab"
-          example: "justsomeuniquestring"
+          description: 'ID of the tab'
+          example: 'justsomeuniquestring'
         title:
           type: string
           minLength: 1
           maxLength: 15
-          example: "Start"
+          example: 'Start'
         type:
           type: string
           enum:
@@ -1729,81 +1871,81 @@ components:
           properties:
             ios:
               type: string
-              description: "SF Symbol name"
-              example: "bookmark"
+              description: 'SF Symbol name'
+              example: 'bookmark'
             android:
               type: string
-              description: "Material Design Icon name"
-              example: "bookmarks"
+              description: 'Material Design Icon name'
+              example: 'bookmarks'
         visible-from:
           type: string
-          description: "Time when the tab becomes visible in the app"
-          example: "DAY=MO;TIME=00:00:00"
+          description: 'Time when the tab becomes visible in the app'
+          example: 'DAY=MO;TIME=00:00:00'
         visible-to:
           type: string
-          description: "Time when the tab becomes invisible in the app"
-          example: "DAY=FR;TIME=16:00:00"
+          description: 'Time when the tab becomes invisible in the app'
+          example: 'DAY=FR;TIME=16:00:00'
         menu-left:
           type: string
-          description: "The ID of the menu, which should be shown in the upper left of a tab."
-          example: "navigation_main"
+          description: 'The ID of the menu, which should be shown in the upper left of a tab.'
+          example: 'navigation_main'
         menu-right:
           type: string
-          description: "The ID of the menu, which should be shown in the upper right of a tab."
-          example: "navigation_account"
+          description: 'The ID of the menu, which should be shown in the upper right of a tab.'
+          example: 'navigation_account'
         items:
           type: array
 
     TabCenterpage:
       allOf:
-        - $ref: "#/components/schemas/TabBase"
+        - $ref: '#/components/schemas/TabBase'
         - properties:
             type:
               type: string
               enum:
                 - tab-centerpage
-              example: "tab-centerpage"
+              example: 'tab-centerpage'
             items:
               type: array
               items:
                 oneOf:
-                  - $ref: "#/components/schemas/MenuItemNative"
-                  - $ref: "#/components/schemas/MenuItemWeb"
-                  - $ref: "#/components/schemas/MenuItemTabStart"
+                  - $ref: '#/components/schemas/MenuItemNative'
+                  - $ref: '#/components/schemas/MenuItemWeb'
+                  - $ref: '#/components/schemas/MenuItemTabStart'
                 discriminator:
                   propertyName: type
                   mapping:
-                    menu-item-native: "#/components/schemas/MenuItemNative"
-                    menu-item-web: "#/components/schemas/MenuItemWeb"
-                    menu-item-tab-start: "#/components/schemas/MenuItemTabStart"
+                    menu-item-native: '#/components/schemas/MenuItemNative'
+                    menu-item-web: '#/components/schemas/MenuItemWeb'
+                    menu-item-tab-start: '#/components/schemas/MenuItemTabStart'
 
     TabStory:
       allOf:
-        - $ref: "#/components/schemas/TabBase"
+        - $ref: '#/components/schemas/TabBase'
         - properties:
             type:
               type: string
               enum:
                 - tab-story
-              example: "tab-story"
+              example: 'tab-story'
             items:
               type: array
               items:
-                $ref: "#/components/schemas/MenuItemNative"
+                $ref: '#/components/schemas/MenuItemNative'
 
     TabMenu:
       allOf:
-        - $ref: "#/components/schemas/TabBase"
+        - $ref: '#/components/schemas/TabBase'
         - properties:
             type:
               type: string
               enum:
                 - tab-menu
-              example: "tab-menu"
+              example: 'tab-menu'
             items:
               type: array
               items:
-                $ref: "#/components/schemas/MenuSection"
+                $ref: '#/components/schemas/MenuSection'
 
     MenuBase:
       required:
@@ -1815,11 +1957,11 @@ components:
       properties:
         id:
           type: string
-          description: "ID of the navigation"
-          example: "justsomeuniquestring"
+          description: 'ID of the navigation'
+          example: 'justsomeuniquestring'
         title:
           type: string
-          example: "Menü"
+          example: 'Menü'
         type:
           type: string
           enum:
@@ -1830,51 +1972,51 @@ components:
           properties:
             ios:
               type: string
-              description: "SF Symbol name"
-              example: "bookmark"
+              description: 'SF Symbol name'
+              example: 'bookmark'
             android:
               type: string
-              description: "Material Design Icon name"
-              example: "bookmarks"
+              description: 'Material Design Icon name'
+              example: 'bookmarks'
         items:
           type: array
 
     ContentMenu:
       allOf:
-        - $ref: "#/components/schemas/MenuBase"
+        - $ref: '#/components/schemas/MenuBase'
         - properties:
             type:
               type: string
               enum:
                 - content-menu
-              example: "content-menu"
+              example: 'content-menu'
             items:
               type: array
               items:
-                $ref: "#/components/schemas/MenuSection"
+                $ref: '#/components/schemas/MenuSection'
 
     UserMenu:
       allOf:
-        - $ref: "#/components/schemas/MenuBase"
+        - $ref: '#/components/schemas/MenuBase'
         - properties:
             type:
               type: string
               enum:
                 - user-menu
-              example: "user-menu"
+              example: 'user-menu'
             items:
               type: array
               items:
-                $ref: "#/components/schemas/MenuSection"
+                $ref: '#/components/schemas/MenuSection'
 
     MenuSection:
       properties:
         id:
           type: string
-          example: "menu-section-1"
+          example: 'menu-section-1'
         title:
           type: string
-          example: "My section"
+          example: 'My section'
         split:
           type: boolean
           example: false
@@ -1888,21 +2030,21 @@ components:
           type: array
           items:
             oneOf:
-              - $ref: "#/components/schemas/MenuItemNative"
-              - $ref: "#/components/schemas/MenuItemApp"
-              - $ref: "#/components/schemas/MenuItemWeb"
-              - $ref: "#/components/schemas/MenuItemBrowser"
-              - $ref: "#/components/schemas/MenuItemSubMenu"
-              - $ref: "#/components/schemas/MenuItemTabStart"
+              - $ref: '#/components/schemas/MenuItemNative'
+              - $ref: '#/components/schemas/MenuItemApp'
+              - $ref: '#/components/schemas/MenuItemWeb'
+              - $ref: '#/components/schemas/MenuItemBrowser'
+              - $ref: '#/components/schemas/MenuItemSubMenu'
+              - $ref: '#/components/schemas/MenuItemTabStart'
             discriminator:
               propertyName: type
               mapping:
-                menu-item-native: "#/components/schemas/MenuItemNative"
-                menu-item-app: "#/components/schemas/MenuItemApp"
-                menu-item-web: "#/components/schemas/MenuItemWeb"
-                menu-item-browser: "#/components/schemas/MenuItemBrowser"
-                menu-item-submenu: "#/components/schemas/MenuItemSubMenu"
-                menu-item-tab-start: "#/components/schemas/MenuItemTabStart"
+                menu-item-native: '#/components/schemas/MenuItemNative'
+                menu-item-app: '#/components/schemas/MenuItemApp'
+                menu-item-web: '#/components/schemas/MenuItemWeb'
+                menu-item-browser: '#/components/schemas/MenuItemBrowser'
+                menu-item-submenu: '#/components/schemas/MenuItemSubMenu'
+                menu-item-tab-start: '#/components/schemas/MenuItemTabStart'
 
     MenuItemBase:
       required:
@@ -1912,10 +2054,10 @@ components:
       properties:
         id:
           type: string
-          example: "menu-entry1"
+          example: 'menu-entry1'
         title:
           type: string
-          example: "Menu Entry Title"
+          example: 'Menu Entry Title'
         type:
           type: string
           enum:
@@ -1930,16 +2072,16 @@ components:
           properties:
             ios:
               type: string
-              description: "SF Symbol name"
-              example: "bookmark"
+              description: 'SF Symbol name'
+              example: 'bookmark'
             android:
               type: string
-              description: "Material Design Icon name"
-              example: "bookmarks"
+              description: 'Material Design Icon name'
+              example: 'bookmarks'
 
     MenuItemNative:
       allOf:
-        - $ref: "#/components/schemas/MenuItemBase"
+        - $ref: '#/components/schemas/MenuItemBase'
         - required:
             - source
           properties:
@@ -1947,13 +2089,13 @@ components:
               type: string
               enum:
                 - menu-item-native
-              example: "menu-item-native"
+              example: 'menu-item-native'
             source:
-              $ref: "#/components/schemas/UUID"
+              $ref: '#/components/schemas/UUID'
 
     MenuItemApp:
       allOf:
-        - $ref: "#/components/schemas/MenuItemBase"
+        - $ref: '#/components/schemas/MenuItemBase'
         - required:
             - targetId
           properties:
@@ -1961,62 +2103,62 @@ components:
               type: string
               enum:
                 - menu-item-app
-              example: "menu-item-app"
+              example: 'menu-item-app'
             targetId:
               type: string
-              example: "some-app-id"
+              example: 'some-app-id'
 
     MenuItemWeb:
       allOf:
-        - $ref: "#/components/schemas/MenuItemBase"
+        - $ref: '#/components/schemas/MenuItemBase'
         - required:
             - url
           properties:
             url:
               type: string
               # format: uri
-              example: "https://www.zeit.de/some/webviewurl"
+              example: 'https://www.zeit.de/some/webviewurl'
             type:
               type: string
               enum:
                 - menu-item-web
-              example: "menu-item-web"
+              example: 'menu-item-web'
 
     MenuItemBrowser:
       allOf:
-        - $ref: "#/components/schemas/MenuItemBase"
+        - $ref: '#/components/schemas/MenuItemBase'
         - required:
             - url
           properties:
             url:
               type: string
               # format: uri
-              example: "https://www.zeit.de/some/browserurl"
+              example: 'https://www.zeit.de/some/browserurl'
             type:
               type: string
               enum:
                 - menu-item-browser
-              example: "menu-item-browser"
+              example: 'menu-item-browser'
 
     MenuItemTabStart:
       allOf:
-        - $ref: "#/components/schemas/MenuItemBase"
+        - $ref: '#/components/schemas/MenuItemBase'
         - required:
             - url
           properties:
             url:
               type: string
               # format: uri
-              example: "https://www.zeit.de/some/webviewurl"
+              example: 'https://www.zeit.de/some/webviewurl'
             type:
               type: string
               enum:
                 - menu-item-tab-start
-              example: "menu-item-tab-start"
+              example: 'menu-item-tab-start'
 
     MenuItemSubMenu:
       allOf:
-        - $ref: "#/components/schemas/MenuItemBase"
+        - $ref: '#/components/schemas/MenuItemBase'
         - required:
             - items
           properties:
@@ -2028,17 +2170,17 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: "#/components/schemas/MenuItemNative"
-                  - $ref: "#/components/schemas/MenuItemApp"
-                  - $ref: "#/components/schemas/MenuItemWeb"
-                  - $ref: "#/components/schemas/MenuItemBrowser"
+                  - $ref: '#/components/schemas/MenuItemNative'
+                  - $ref: '#/components/schemas/MenuItemApp'
+                  - $ref: '#/components/schemas/MenuItemWeb'
+                  - $ref: '#/components/schemas/MenuItemBrowser'
                 discriminator:
                   propertyName: type
                   mapping:
-                    menu-item-native: "#/components/schemas/MenuItemNative"
-                    menu-item-app: "#/components/schemas/MenuItemApp"
-                    menu-item-web: "#/components/schemas/MenuItemWeb"
-                    menu-item-browser: "#/components/schemas/MenuItemBrowser"
+                    menu-item-native: '#/components/schemas/MenuItemNative'
+                    menu-item-app: '#/components/schemas/MenuItemApp'
+                    menu-item-web: '#/components/schemas/MenuItemWeb'
+                    menu-item-browser: '#/components/schemas/MenuItemBrowser'
 
     AppStoreType:
       type: string

--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1,26 +1,26 @@
 openapi: 3.0.2
 info:
-  description: 'This is the API description for the ZON-App (iOS and Android)'
-  version: '0.3.1'
-  title: 'ZON App API'
+  description: "This is the API description for the ZON-App (iOS and Android)"
+  version: "0.3.1"
+  title: "ZON App API"
   contact:
-    email: 'internet-technik@zeit.de'
+    email: "internet-technik@zeit.de"
 
 servers:
-  - url: 'https://zappi.zeit.de/{version}'
-    description: 'Production'
+  - url: "https://zappi.zeit.de/{version}"
+    description: "Production"
     variables:
       version:
-        default: '0.3.1'
+        default: "0.3.1"
         enum: # list older still available versions here
-          - '0.3.1'
-  - url: 'https://zappi.staging.zeit.de/{version}'
-    description: 'Staging'
+          - "0.3.1"
+  - url: "https://zappi.staging.zeit.de/{version}"
+    description: "Staging"
     variables:
       version:
-        default: '0.3.1'
+        default: "0.3.1"
         enum:
-          - '0.3.1'
+          - "0.3.1"
 
 paths:
   /content/teaser/{uuid}:
@@ -31,27 +31,27 @@ paths:
           name: uuid
           required: true
           schema:
-            $ref: '#/components/schemas/UUID'
+            $ref: "#/components/schemas/UUID"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/CenterpageTeaser'
-                  - $ref: '#/components/schemas/CenterpageTeaserGallery'
-                  - $ref: '#/components/schemas/CenterpageTeaserVideo'
-                  - $ref: '#/components/schemas/CenterpageTeaserPodcast'
-                  - $ref: '#/components/schemas/CenterpageTeaserAudio'
-          description: 'Success'
-        '400':
-          description: 'Something was wrong. Check the body for error messages.'
-        '401':
-          description: 'Unauthorized to get teaser'
-        '404':
-          description: 'Not found'
-        '503':
-          description: 'Service unavailable'
+                  - $ref: "#/components/schemas/CenterpageTeaser"
+                  - $ref: "#/components/schemas/CenterpageTeaserGallery"
+                  - $ref: "#/components/schemas/CenterpageTeaserVideo"
+                  - $ref: "#/components/schemas/CenterpageTeaserPodcast"
+                  - $ref: "#/components/schemas/CenterpageTeaserAudio"
+          description: "Success"
+        "400":
+          description: "Something was wrong. Check the body for error messages."
+        "401":
+          description: "Unauthorized to get teaser"
+        "404":
+          description: "Not found"
+        "503":
+          description: "Service unavailable"
 
   /merkl/bookmarks:
     get:
@@ -69,24 +69,24 @@ paths:
           schema:
             type: string
             description: Category
-            example: 'podcast'
+            example: "podcast"
           description: category to filter list of bookmarks
-          example: '?category=podcast'
+          example: "?category=podcast"
       tags:
         - bookmarks
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/bookmark'
-          description: 'Return list of bookmarks, optionally filtered by category'
-        '400':
-          description: 'Something went wrong with the request to get bookmarks. Check the body for error messages.'
-        '401':
-          description: 'Unauthorized (to get bookmarks)'
-        '503':
-          description: 'Service unavailable (when getting bookmarks)'
+                $ref: "#/components/schemas/bookmark"
+          description: "Return list of bookmarks, optionally filtered by category"
+        "400":
+          description: "Something went wrong with the request to get bookmarks. Check the body for error messages."
+        "401":
+          description: "Unauthorized (to get bookmarks)"
+        "503":
+          description: "Service unavailable (when getting bookmarks)"
     post:
       security:
         - cookieAuthProduction: []
@@ -104,27 +104,27 @@ paths:
               type: object
               properties:
                 uuid:
-                  $ref: '#/components/schemas/UUID'
+                  $ref: "#/components/schemas/UUID"
               required:
                 - uuid
               additionalProperties: false
       responses:
-        '201':
-          description: 'Saved entry to bookmarks (returning it)'
-        '204':
-          description: 'Saved entry to bookmarks (without returning it)'
-        '400':
-          description: 'Something went wrong with the request to save bookmark. Check the body for error messages.'
-        '401':
-          description: 'Unauthorized (to save bookmark)'
-        '403':
-          description: 'Forbidden (to save bookmark)'
-        '409':
+        "201":
+          description: "Saved entry to bookmarks (returning it)"
+        "204":
+          description: "Saved entry to bookmarks (without returning it)"
+        "400":
+          description: "Something went wrong with the request to save bookmark. Check the body for error messages."
+        "401":
+          description: "Unauthorized (to save bookmark)"
+        "403":
+          description: "Forbidden (to save bookmark)"
+        "409":
           description: "Bookmark already exists. You can't bookmark the same document twice."
-        '502':
-          description: 'Bad gateway (when saving bookmark)'
-        '503':
-          description: 'Service unavailable (when saving bookmark)'
+        "502":
+          description: "Bad gateway (when saving bookmark)"
+        "503":
+          description: "Service unavailable (when saving bookmark)"
     delete:
       security:
         - cookieAuthProduction: []
@@ -143,21 +143,21 @@ paths:
           name: uuid
           required: false
           schema:
-            $ref: '#/components/schemas/uuidfilter'
+            $ref: "#/components/schemas/uuidfilter"
           description: UUID of an article
       responses:
-        '204':
-          description: 'Deleted entry from bookmarks or delete all bookmarks, respectively'
-        '400':
-          description: 'Something went wrong with the request to delete a bookmark. Check the body for error messages.'
-        '401':
-          description: 'Unauthorized (to delete bookmark)'
-        '403':
-          description: 'Forbidden (to delete bookmark)'
-        '502':
-          description: 'Bad gateway (when deleting bookmark)'
-        '503':
-          description: 'Service unavailable (when deleting bookmarks)'
+        "204":
+          description: "Deleted entry from bookmarks or delete all bookmarks, respectively"
+        "400":
+          description: "Something went wrong with the request to delete a bookmark. Check the body for error messages."
+        "401":
+          description: "Unauthorized (to delete bookmark)"
+        "403":
+          description: "Forbidden (to delete bookmark)"
+        "502":
+          description: "Bad gateway (when deleting bookmark)"
+        "503":
+          description: "Service unavailable (when deleting bookmarks)"
 
   /merkl/categories:
     get:
@@ -169,7 +169,7 @@ paths:
       tags:
         - categories
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
@@ -187,35 +187,35 @@ paths:
                     - count
                     - name
                   additionalProperties: false
-          description: 'Success getting each category name with count of its bookmarks'
-        '400':
-          description: 'Something went wrong with the request to get categories. Check the body for error messages.'
-        '401':
-          description: 'Unauthorized (to get categories)'
-        '503':
-          description: 'Service unavailable (when getting categories)'
+          description: "Success getting each category name with count of its bookmarks"
+        "400":
+          description: "Something went wrong with the request to get categories. Check the body for error messages."
+        "401":
+          description: "Unauthorized (to get categories)"
+        "503":
+          description: "Service unavailable (when getting categories)"
 
   /bookmarks:
     get:
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: 'Returns the list of bookmarks'
+      summary: "Returns the list of bookmarks"
       tags:
         - bookmarks
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Centerpage'
-          description: 'Success'
-        '400':
-          description: 'Something was wrong with the request. Check the body for error messages.'
-        '401':
-          description: 'Unauthorized'
-        '503':
-          description: 'Service unavailable'
+                $ref: "#/components/schemas/Centerpage"
+          description: "Success"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "401":
+          description: "Unauthorized"
+        "503":
+          description: "Service unavailable"
     post:
       security:
         - cookieAuthProduction: []
@@ -229,22 +229,22 @@ paths:
               type: object
               properties:
                 id:
-                  $ref: '#/components/schemas/UUID'
+                  $ref: "#/components/schemas/UUID"
       responses:
-        '201':
-          description: 'Saved entry to bookmarks'
-        '204':
-          description: 'Saved entry to bookmarks'
-        '400':
-          description: 'Something was wrong with the request. Check the body for error messages.'
-        '401':
-          description: 'Unauthorized'
-        '403':
-          description: 'Forbidden'
-        '502':
-          description: 'Bad gateway'
-        '503':
-          description: 'Service unavailable'
+        "201":
+          description: "Saved entry to bookmarks"
+        "204":
+          description: "Saved entry to bookmarks"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "502":
+          description: "Bad gateway"
+        "503":
+          description: "Service unavailable"
 
   /bookmarks/{uuid}:
     delete:
@@ -256,42 +256,42 @@ paths:
           name: uuid
           required: true
           schema:
-            $ref: '#/components/schemas/UUID'
+            $ref: "#/components/schemas/UUID"
       responses:
-        '204':
-          description: 'Deleted entry from bookmarks'
-        '400':
-          description: 'Something was wrong with the request. Check the body for error messages.'
-        '401':
-          description: 'Unauthorized'
-        '403':
-          description: 'Forbidden'
-        '502':
-          description: 'Bad gateway'
-        '503':
-          description: 'Service unavailable'
+        "204":
+          description: "Deleted entry from bookmarks"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "502":
+          description: "Bad gateway"
+        "503":
+          description: "Service unavailable"
 
   /bookmarks/ids:
     get:
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: 'Returns the list of bookmarked ids'
+      summary: "Returns the list of bookmarked ids"
       tags:
         - bookmarks
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BookmarkIds'
-          description: 'Success'
-        '400':
-          description: 'Something was wrong with the request. Check the body for error messages.'
-        '401':
-          description: 'Unauthorized'
-        '503':
-          description: 'Service unavailable'
+                $ref: "#/components/schemas/BookmarkIds"
+          description: "Success"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "401":
+          description: "Unauthorized"
+        "503":
+          description: "Service unavailable"
 
   /config/{filename}:
     get:
@@ -301,23 +301,23 @@ paths:
           schema:
             type: string
           required: true
-          description: 'The filename of the configuration file'
+          description: "The filename of the configuration file"
       summary: |
         Provides JSON formatted configuration files. These are maintained
         via the CMS and can change independently of API releases.
         By convention, these reside in the folder
         ``https://vivi.zeit.de/repository/static/zona``
       responses:
-        '200':
-          description: 'Success'
+        "200":
+          description: "Success"
           content:
             application/json:
               schema:
                 type: object
-        '400':
-          description: 'No valid JSON for this resource'
-        '404':
-          description: 'No such configuration file'
+        "400":
+          description: "No valid JSON for this resource"
+        "404":
+          description: "No such configuration file"
 
   /cp/{uuid}:
     get:
@@ -325,36 +325,36 @@ paths:
         - in: path
           name: uuid
           schema:
-            $ref: '#/components/schemas/UUID'
+            $ref: "#/components/schemas/UUID"
           required: true
-          description: 'UUID from CMS that identifies a CenterPage content object'
+          description: "UUID from CMS that identifies a CenterPage content object"
 
       tags:
         - cp
-      summary: 'Returns the teasers (i.e. content references) on a CenterPage'
+      summary: "Returns the teasers (i.e. content references) on a CenterPage"
       responses:
-        '200':
-          description: 'Success'
+        "200":
+          description: "Success"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Centerpage'
-        '400':
-          description: 'Something was wrong with the request. Check the body for error messages.'
-        '404':
-          description: 'No centerpage found for the given uuid'
+                $ref: "#/components/schemas/Centerpage"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "404":
+          description: "No centerpage found for the given uuid"
 
   /freebies/freebies:
     get:
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: 'Returns the list of freebies'
+      summary: "Returns the list of freebies"
       operationId: getFreebies
       tags:
         - freebies
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
@@ -369,20 +369,20 @@ paths:
                   properties:
                     token:
                       type: string
-                      example: '8116c8ea'
+                      example: "8116c8ea"
                     content:
-                      $ref: '#/components/schemas/UUID'
+                      $ref: "#/components/schemas/UUID"
                     path:
                       type: string
-                      example: '/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources'
+                      example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
                     created:
                       type: string
-                      example: '2023-11-29T11:42:32.452605+00:00'
-          description: 'Success'
-        '400':
-          description: 'Bad Request'
-        '401':
-          description: 'Unauthorized'
+                      example: "2023-11-29T11:42:32.452605+00:00"
+          description: "Success"
+        "400":
+          description: "Bad Request"
+        "401":
+          description: "Unauthorized"
     post:
       security:
         - cookieAuthProduction: []
@@ -402,33 +402,33 @@ paths:
                 - path
               properties:
                 content:
-                  $ref: '#/components/schemas/UUID'
+                  $ref: "#/components/schemas/UUID"
                 path:
                   type: string
-                  example: '/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources'
+                  example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
       responses:
-        '201':
-          description: 'Saved entry to freebies'
-        '400':
-          description: 'Bad Request'
-        '401':
-          description: 'Unauthorized'
-        '403':
-          description: 'Forbidden'
-        '429':
-          description: 'Monthly limit exceeded'
+        "201":
+          description: "Saved entry to freebies"
+        "400":
+          description: "Bad Request"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "429":
+          description: "Monthly limit exceeded"
 
   /freebies/allowance:
     get:
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
-      summary: 'Returns the list of allowance'
+      summary: "Returns the list of allowance"
       operationId: getMonthlyAllowance
       tags:
         - freebies
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
@@ -445,15 +445,15 @@ paths:
                     used:
                       type: integer
                       example: 2
-          description: 'Success'
-        '400':
-          description: 'Bad Request'
-        '401':
-          description: 'Unauthorized'
+          description: "Success"
+        "400":
+          description: "Bad Request"
+        "401":
+          description: "Unauthorized"
 
   /freebies/rpc/check:
     post:
-      summary: 'Validate a freebie'
+      summary: "Validate a freebie"
       operationId: checkFreebie
       tags:
         - freebies
@@ -469,12 +469,12 @@ paths:
               properties:
                 token:
                   type: string
-                  example: '8116c8ea'
+                  example: "8116c8ea"
                 path:
                   type: string
-                  example: '/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources'
+                  example: "/2023/33/lithium-vorkommen-deutschland-e-autos-vulcan-energy-resources"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
@@ -487,12 +487,12 @@ paths:
                     type: integer
                     example: 1
                   content:
-                    $ref: '#/components/schemas/UUID'
-          description: 'Success'
-        '400':
-          description: 'Bad Request'
-        '404':
-          description: 'Expired or non-existing freebie'
+                    $ref: "#/components/schemas/UUID"
+          description: "Success"
+        "400":
+          description: "Bad Request"
+        "404":
+          description: "Expired or non-existing freebie"
 
   /summy/summaries:
     get:
@@ -507,15 +507,15 @@ paths:
           in: query
           schema:
             type: string
-            pattern: '^eq.[-a-f0-9]+$'
+            pattern: "^eq.[-a-f0-9]+$"
       responses:
-        '200':
+        "200":
           description: return summaries
           content:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/summaries'
+                  $ref: "#/components/schemas/summaries"
 
   /summy/feedback:
     post:
@@ -530,9 +530,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/feedback'
+              $ref: "#/components/schemas/feedback"
       responses:
-        '201':
+        "201":
           description: Created.
 
   /iap/receipts/{platform}:
@@ -542,8 +542,8 @@ paths:
           name: platform
           required: true
           schema:
-            $ref: '#/components/schemas/AppStoreType'
-      requestBody: { $ref: '#/components/requestBodies/AppStoreReceipt' }
+            $ref: "#/components/schemas/AppStoreType"
+      requestBody: { $ref: "#/components/requestBodies/AppStoreReceipt" }
       security:
         - cookieAuthProduction: []
         - cookieAuthStaging: []
@@ -559,78 +559,78 @@ paths:
           "real" account, the response will have the cookie for that real account set. Clients are expected to notice the
           discrepancy and use the new cookie henceforth.
       responses:
-        '204':
-          description: 'All is well. Enjoy those exclusive articles!'
-        '400':
-          description: 'Something was wrong with the request. Check the body for error messages.'
-        '401':
-          description: 'No valid identities were found in the receipt.'
-        '502':
-          description: 'The payment server was not reachable.'
+        "204":
+          description: "All is well. Enjoy those exclusive articles!"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "401":
+          description: "No valid identities were found in the receipt."
+        "502":
+          description: "The payment server was not reachable."
 
   /search:
     get:
       tags:
         - search
-      summary: 'Main entry point for generic search.'
+      summary: "Main entry point for generic search."
       parameters:
         - in: query
           name: q
           schema:
             type: string
           required: true
-          description: 'The term that should be searched for'
+          description: "The term that should be searched for"
       responses:
-        '200':
-          description: 'Returns a list of results'
+        "200":
+          description: "Returns a list of results"
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   adControllerPageInfo:
-                    $ref: '#/components/schemas/AdControllerPageInfo'
+                    $ref: "#/components/schemas/AdControllerPageInfo"
                   items:
                     type: array
                     items:
                       oneOf:
-                        - $ref: '#/components/schemas/CenterpageAdplace'
-                        - $ref: '#/components/schemas/CenterpageTeaser'
-                        - $ref: '#/components/schemas/CenterpageTeaserAuthor'
-                        - $ref: '#/components/schemas/CenterpageTeaserGallery'
-                        - $ref: '#/components/schemas/CenterpageTeaserVideo'
-                        - $ref: '#/components/schemas/CenterpageTeaserPodcast'
-                        - $ref: '#/components/schemas/CenterpageTeaserAudio'
-                        - $ref: '#/components/schemas/CenterpageModuleHTML'
+                        - $ref: "#/components/schemas/CenterpageAdplace"
+                        - $ref: "#/components/schemas/CenterpageTeaser"
+                        - $ref: "#/components/schemas/CenterpageTeaserAuthor"
+                        - $ref: "#/components/schemas/CenterpageTeaserGallery"
+                        - $ref: "#/components/schemas/CenterpageTeaserVideo"
+                        - $ref: "#/components/schemas/CenterpageTeaserPodcast"
+                        - $ref: "#/components/schemas/CenterpageTeaserAudio"
+                        - $ref: "#/components/schemas/CenterpageModuleHTML"
                       discriminator:
                         propertyName: type
                         mapping:
-                          adplace: '#/components/schemas/CenterpageAdplace'
-                          teaser: '#/components/schemas/CenterpageTeaser'
-                          teaser-author: '#/components/schemas/CenterpageTeaserAuthor'
-                          teaser-gallery: '#/components/schemas/CenterpageTeaserGallery'
-                          teaser-video: '#/components/schemas/CenterpageTeaserVideo'
-                          teaser-podcast: '#/components/schemas/CenterpageTeaserPodcast'
-                          teaser-audio: '#/components/schemas/CenterpageTeaserAudio'
-                          html: '#/components/schemas/CenterpageModuleHTML'
+                          adplace: "#/components/schemas/CenterpageAdplace"
+                          teaser: "#/components/schemas/CenterpageTeaser"
+                          teaser-author: "#/components/schemas/CenterpageTeaserAuthor"
+                          teaser-gallery: "#/components/schemas/CenterpageTeaserGallery"
+                          teaser-video: "#/components/schemas/CenterpageTeaserVideo"
+                          teaser-podcast: "#/components/schemas/CenterpageTeaserPodcast"
+                          teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
+                          html: "#/components/schemas/CenterpageModuleHTML"
                   trackingData:
-                    $ref: '#/components/schemas/TrackingData'
-        '400':
-          description: 'Invalid query, see response body for details.'
+                    $ref: "#/components/schemas/TrackingData"
+        "400":
+          description: "Invalid query, see response body for details."
 
   /structure:
     get:
       tags:
         - structure
-      summary: 'Returns tab and menu/submenu configuration for the app UI'
+      summary: "Returns tab and menu/submenu configuration for the app UI"
       responses:
-        '200':
+        "200":
           # XXX description is required, but really already exists in ..summary
-          description: 'Success'
+          description: "Success"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Structure'
+                $ref: "#/components/schemas/Structure"
               example:
                 {
                   tabs:
@@ -646,37 +646,37 @@ paths:
                               id: homepage,
                               title: Aktuell,
                               type: menu-item-web,
-                              url: 'https://www.zeit.de/index',
+                              url: "https://www.zeit.de/index",
                             },
                             {
                               id: ressortPolitik,
                               title: Politik,
                               type: menu-item-native,
-                              source: '{urn:uuid:b4d1e3b1-aac4-4a80-b820-e4093fe24a36}',
+                              source: "{urn:uuid:b4d1e3b1-aac4-4a80-b820-e4093fe24a36}",
                             },
                             {
                               id: ressortGesellschaft,
                               title: Gesellschaft,
                               type: menu-item-native,
-                              source: '{urn:uuid:c92ad9be-67e0-497d-beee-6c2e063352cc}',
+                              source: "{urn:uuid:c92ad9be-67e0-497d-beee-6c2e063352cc}",
                             },
                             {
                               id: ressortWirtschaft,
                               title: Wirtschaft,
                               type: menu-item-native,
-                              source: '{urn:uuid:ea13ef02-74f3-4010-8cd7-777327fb881a}',
+                              source: "{urn:uuid:ea13ef02-74f3-4010-8cd7-777327fb881a}",
                             },
                             {
                               id: ressortWissen,
                               title: Wissen,
                               type: menu-item-native,
-                              source: '{urn:uuid:c84692ca-b0c9-4772-8c6b-85e2abc446e1}',
+                              source: "{urn:uuid:c84692ca-b0c9-4772-8c6b-85e2abc446e1}",
                             },
                             {
                               id: ressortKultur,
                               title: Kultur,
                               type: menu-item-native,
-                              source: '{urn:uuid:49b109f0-bbad-495e-8a88-ad91ec1ef8f9}',
+                              source: "{urn:uuid:49b109f0-bbad-495e-8a88-ad91ec1ef8f9}",
                             },
                           ],
                       },
@@ -689,21 +689,21 @@ paths:
                           [
                             {
                               id: newsAll,
-                              title: 'Alle Schlagzeilen',
+                              title: "Alle Schlagzeilen",
                               type: menu-item-native,
-                              source: '{urn:uuid:08945d5e-483c-4e7b-9843-69a8f590ada9}',
+                              source: "{urn:uuid:08945d5e-483c-4e7b-9843-69a8f590ada9}",
                             },
                             {
                               id: newsMostImportant,
-                              title: 'Die wichtigsten Nachrichten',
+                              title: "Die wichtigsten Nachrichten",
                               type: menu-item-native,
-                              source: '{urn:uuid:df60a52c-5f4d-4804-833d-ec31e24dbd43}',
+                              source: "{urn:uuid:df60a52c-5f4d-4804-833d-ec31e24dbd43}",
                             },
                             {
                               id: newsAnalysisAndReports,
-                              title: 'Analysen und Hintergründe',
+                              title: "Analysen und Hintergründe",
                               type: menu-item-native,
-                              source: '{urn:uuid:d6913463-1804-466d-b6d0-34376ef21916}',
+                              source: "{urn:uuid:d6913463-1804-466d-b6d0-34376ef21916}",
                             },
                           ],
                       },
@@ -718,7 +718,7 @@ paths:
                               id: explore-all,
                               title: Entdecken,
                               type: menu-item-native,
-                              source: '{urn:uuid:99ae6607-fe0f-44ad-97fb-00dd0d852c30}',
+                              source: "{urn:uuid:99ae6607-fe0f-44ad-97fb-00dd0d852c30}",
                             },
                           ],
                       },
@@ -731,21 +731,21 @@ paths:
                           [
                             {
                               id: exclusive,
-                              title: 'Exklusive Artikel',
+                              title: "Exklusive Artikel",
                               type: menu-item-native,
-                              source: '{urn:uuid:0fd9480f-1b52-4fcb-942e-8089e378102e}',
+                              source: "{urn:uuid:0fd9480f-1b52-4fcb-942e-8089e378102e}",
                             },
                             {
                               id: zeitPDFWebReader,
-                              title: 'DIE ZEIT',
+                              title: "DIE ZEIT",
                               type: menu-item-web,
-                              url: 'https://epaper.zeit.de/abo/diezeit',
+                              url: "https://epaper.zeit.de/abo/diezeit",
                             },
                             {
                               id: wochenMarkt,
-                              title: 'Wochenmarkt',
+                              title: "Wochenmarkt",
                               type: menu-item-web,
-                              url: 'https://www.zeit.de/wochenmarkt',
+                              url: "https://www.zeit.de/wochenmarkt",
                             },
                           ],
                       },
@@ -758,7 +758,7 @@ paths:
                           [
                             {
                               id: user-menu,
-                              title: 'Mein Bereich',
+                              title: "Mein Bereich",
                               items:
                                 [
                                   {
@@ -777,7 +777,7 @@ paths:
                                     id: comment-list,
                                     title: Kommentare,
                                     type: menu-item-web,
-                                    url: 'https://profile.zeit.de',
+                                    url: "https://profile.zeit.de",
                                   },
                                 ],
                             },
@@ -796,19 +796,19 @@ paths:
                                           id: ad1,
                                           title: Werbung,
                                           type: menu-item-web,
-                                          url: 'https://www.werbung.de',
+                                          url: "https://www.werbung.de",
                                         },
                                         {
                                           id: ad2,
                                           title: Anzeige,
                                           type: menu-item-web,
-                                          url: 'https://www.werbung.de',
+                                          url: "https://www.werbung.de",
                                         },
                                         {
                                           id: ad3,
                                           title: Promo,
                                           type: menu-item-web,
-                                          url: 'https://www.werbung.de',
+                                          url: "https://www.werbung.de",
                                         },
                                       ],
                                   },
@@ -818,8 +818,8 @@ paths:
                       },
                     ],
                 }
-        '400':
-          description: 'Something was wrong with the request. Check the body for error messages.'
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
 
   /user:
     get:
@@ -829,42 +829,42 @@ paths:
         - cookieAuthTesting: []
       tags:
         - user
-      summary: 'Returns information about the current user'
+      summary: "Returns information about the current user"
       responses:
-        '200':
-          description: 'Information about the currently logged in user'
+        "200":
+          description: "Information about the currently logged in user"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserInfo'
-        '400':
-          description: 'Something was wrong with the request. Check the body for error messages.'
-        '401':
-          description: 'The user is not logged in'
+                $ref: "#/components/schemas/UserInfo"
+        "400":
+          description: "Something was wrong with the request. Check the body for error messages."
+        "401":
+          description: "The user is not logged in"
 
 components:
   requestBodies:
     AppStoreReceipt:
       content:
-        'text/plain': { 'schema': { '$ref': '#/components/schemas/AppStoreReceipt' } }
+        "text/plain": { "schema": { "$ref": "#/components/schemas/AppStoreReceipt" } }
 
   schemas:
     UUID:
       type: string
       pattern: "^((\\{urn:uuid:)?([a-f0-9]{8})(-[a-f0-9]{4}){3}(-[a-f0-9]{12})\\}?|[-a-z0-9/]+)$"
-      description: 'CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted.'
-      example: '{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda} or d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda'
+      description: "CMS UUID that denotes a content object. For testing/development, a CMS path is also accepted."
+      example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda} or d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda"
 
     UUIDList:
       type: array
       items:
-        $ref: '#/components/schemas/UUID'
+        $ref: "#/components/schemas/UUID"
 
     uuidfilter:
       type: string
       pattern: ^[eq\.]+(([a-f0-9]{8})(-[a-f0-9]{4}){3}(-[a-f0-9]{12})\\}?|[-a-z0-9/]+)$
       description: Postgrest equal filter function
-      example: 'eq.d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda'
+      example: "eq.d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda"
 
     bookmark:
       type: array
@@ -874,12 +874,12 @@ components:
         properties:
           created:
             type: string
-            example: '2022-11-25T16:18:37.124812+00:00'
+            example: "2022-11-25T16:18:37.124812+00:00"
           ssoid:
             type: integer
             example: 42
           uuid:
-            $ref: '#/components/schemas/UUID'
+            $ref: "#/components/schemas/UUID"
         required:
           - created
           - ssoid
@@ -889,7 +889,7 @@ components:
     BookmarkIds:
       type: object
       items:
-        $ref: '#/components/schemas/UUIDList'
+        $ref: "#/components/schemas/UUIDList"
 
     ContentEntitlements:
       type: array
@@ -911,85 +911,85 @@ components:
           type: array
           items:
             oneOf:
-              - $ref: '#/components/schemas/TabCenterpage'
-              - $ref: '#/components/schemas/TabMenu'
-              - $ref: '#/components/schemas/TabStory'
+              - $ref: "#/components/schemas/TabCenterpage"
+              - $ref: "#/components/schemas/TabMenu"
+              - $ref: "#/components/schemas/TabStory"
             discriminator:
               propertyName: type
               mapping:
-                tab-centerpage: '#/components/schemas/TabCenterpage'
-                tab-menu: '#/components/schemas/TabMenu'
-                tab-story: '#/components/schemas/TabStory'
+                tab-centerpage: "#/components/schemas/TabCenterpage"
+                tab-menu: "#/components/schemas/TabMenu"
+                tab-story: "#/components/schemas/TabStory"
         menus:
           type: array
           items:
             oneOf:
-              - $ref: '#/components/schemas/ContentMenu'
-              - $ref: '#/components/schemas/UserMenu'
+              - $ref: "#/components/schemas/ContentMenu"
+              - $ref: "#/components/schemas/UserMenu"
             discriminator:
               propertyName: type
               mapping:
-                content-menu: '#/components/schemas/ContentMenu'
-                user-menu: '#/components/schemas/UserMenu'
+                content-menu: "#/components/schemas/ContentMenu"
+                user-menu: "#/components/schemas/UserMenu"
 
     Centerpage:
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/UUID'
+          $ref: "#/components/schemas/UUID"
         url:
           type: string
           # format: uri  XXX only supported in openapi-3.1
-          description: 'Web URL for this CenterPage'
-          example: 'https://www.zeit.de/politik/index'
+          description: "Web URL for this CenterPage"
+          example: "https://www.zeit.de/politik/index"
         pagetitle:
           type: string
         bookmarkable:
           type: boolean
           example: true
         adControllerPageInfo:
-          $ref: '#/components/schemas/AdControllerPageInfo'
+          $ref: "#/components/schemas/AdControllerPageInfo"
         trackingData:
-          $ref: '#/components/schemas/TrackingData'
+          $ref: "#/components/schemas/TrackingData"
         items:
           type: array
           items:
             oneOf:
-              - $ref: '#/components/schemas/CenterpageRegion'
-              - $ref: '#/components/schemas/CenterpageArea'
-              - $ref: '#/components/schemas/CenterpageTeaser'
-              - $ref: '#/components/schemas/CenterpageTeaserAuthor'
-              - $ref: '#/components/schemas/CenterpageTeaserGallery'
-              - $ref: '#/components/schemas/CenterpageTeaserVideo'
-              - $ref: '#/components/schemas/CenterpageTeaserPodcast'
-              - $ref: '#/components/schemas/CenterpageTeaserAudio'
-              - $ref: '#/components/schemas/CenterpageModuleHTML'
-              - $ref: '#/components/schemas/CenterpageAdplace'
-              - $ref: '#/components/schemas/CenterpageHeader'
-              - $ref: '#/components/schemas/CenterpageMarkup'
-              - $ref: '#/components/schemas/CenterpageExtra'
+              - $ref: "#/components/schemas/CenterpageRegion"
+              - $ref: "#/components/schemas/CenterpageArea"
+              - $ref: "#/components/schemas/CenterpageTeaser"
+              - $ref: "#/components/schemas/CenterpageTeaserAuthor"
+              - $ref: "#/components/schemas/CenterpageTeaserGallery"
+              - $ref: "#/components/schemas/CenterpageTeaserVideo"
+              - $ref: "#/components/schemas/CenterpageTeaserPodcast"
+              - $ref: "#/components/schemas/CenterpageTeaserAudio"
+              - $ref: "#/components/schemas/CenterpageModuleHTML"
+              - $ref: "#/components/schemas/CenterpageAdplace"
+              - $ref: "#/components/schemas/CenterpageHeader"
+              - $ref: "#/components/schemas/CenterpageMarkup"
+              - $ref: "#/components/schemas/CenterpageExtra"
             discriminator:
               propertyName: type
               mapping:
-                region: '#/components/schemas/CenterpageRegion'
-                area: '#/components/schemas/CenterpageArea'
-                teaser: '#/components/schemas/CenterpageTeaser'
-                teaser-author: '#/components/schemas/CenterpageTeaserAuthor'
-                teaser-gallery: '#/components/schemas/CenterpageTeaserGallery'
-                teaser-video: '#/components/schemas/CenterpageTeaserVideo'
-                teaser-podcast: '#/components/schemas/CenterpageTeaserPodcast'
-                teaser-audio: '#/components/schemas/CenterpageTeaserAudio'
-                html: '#/components/schemas/CenterpageModuleHTML'
-                adplace: '#/components/schemas/CenterpageAdplace'
-                header: '#/components/schemas/CenterpageHeader'
-                markup: '#/components/schemas/CenterpageMarkup'
-                cpextra: '#/components/schemas/CenterpageExtra'
+                region: "#/components/schemas/CenterpageRegion"
+                area: "#/components/schemas/CenterpageArea"
+                teaser: "#/components/schemas/CenterpageTeaser"
+                teaser-author: "#/components/schemas/CenterpageTeaserAuthor"
+                teaser-gallery: "#/components/schemas/CenterpageTeaserGallery"
+                teaser-video: "#/components/schemas/CenterpageTeaserVideo"
+                teaser-podcast: "#/components/schemas/CenterpageTeaserPodcast"
+                teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
+                html: "#/components/schemas/CenterpageModuleHTML"
+                adplace: "#/components/schemas/CenterpageAdplace"
+                header: "#/components/schemas/CenterpageHeader"
+                markup: "#/components/schemas/CenterpageMarkup"
+                cpextra: "#/components/schemas/CenterpageExtra"
 
     CenterpageElementId:
       type: string
-      pattern: '^id-[-a-f0-9]+$'
-      description: 'ID of the cp element'
-      example: 'id-fcfd3deb-4c26-472b-8bdd-238372d5131b'
+      pattern: "^id-[-a-f0-9]+$"
+      description: "ID of the cp element"
+      example: "id-fcfd3deb-4c26-472b-8bdd-238372d5131b"
 
     CenterpageElementType:
       type: string
@@ -1007,7 +1007,7 @@ components:
         - header
         - markup
         - cpextra
-      description: 'Type of the cp element'
+      description: "Type of the cp element"
 
     AdControllerPageInfo:
       type: object
@@ -1015,25 +1015,25 @@ components:
         doc:
           type: string
           nullable: true
-          description: 'page type'
+          description: "page type"
           enum:
             - homepage
             - index
             - artikel
             - bildgal
             - null
-          example: 'index'
+          example: "index"
         level2:
-          description: 'Level2 property ressort for adplacement'
+          description: "Level2 property ressort for adplacement"
           type: string
-          example: 'politik'
+          example: "politik"
         level3:
-          description: 'Level3 property subressort, name of podcast or series for adplacement'
+          description: "Level3 property subressort, name of podcast or series for adplacement"
           type: string
-          example: 'deutschland'
+          example: "deutschland"
         keywords:
           type: string
-          example: 'zeitonline,coronavirus,frankreich,lockdown'
+          example: "zeitonline,coronavirus,frankreich,lockdown"
 
     Image:
       type: object
@@ -1042,7 +1042,7 @@ components:
         baseUrl:
           type: string
           # format: uri
-          example: 'https://img.zeit.de/2020-08/flightradar-4'
+          example: "https://img.zeit.de/2020-08/flightradar-4"
           description: |
             The URL is a base URL, which needs to be modified with the following query parameters in order to produce an actual image:
 
@@ -1070,7 +1070,7 @@ components:
         fillColor:
           type: string
           nullable: true
-          example: '8ed8a6'
+          example: "8ed8a6"
         visibleMobile:
           type: boolean
           example: false
@@ -1080,148 +1080,148 @@ components:
       properties:
         contentId:
           type: string
-          description: 'Content-ID containing [Unit].[Ressort].[Subressort].[Cluster].[Pagetype].[Sourcetype]|[URL without protocol]'
-          example: 'redaktion.politik.deutschland..centerpage.zede|www.zeit.de/politik/deutschland/index'
+          description: "Content-ID containing [Unit].[Ressort].[Subressort].[Cluster].[Pagetype].[Sourcetype]|[URL without protocol]"
+          example: "redaktion.politik.deutschland..centerpage.zede|www.zeit.de/politik/deutschland/index"
         contentGroup:
-          $ref: '#/components/schemas/TrackingContentGroup'
+          $ref: "#/components/schemas/TrackingContentGroup"
         customParameter:
-          $ref: '#/components/schemas/TrackingCustomParameter'
+          $ref: "#/components/schemas/TrackingCustomParameter"
 
     TrackingContentGroup:
       type: object
-      description: 'Content groups for aggregation'
+      description: "Content groups for aggregation"
       properties:
         1:
           type: string
-          description: 'Unit'
-          example: 'redaktion'
+          description: "Unit"
+          example: "redaktion"
         2:
           type: string
-          description: 'Pagetype'
-          example: 'centerpage'
+          description: "Pagetype"
+          example: "centerpage"
         3:
           type: string
-          description: 'Ressort'
-          example: 'politik'
+          description: "Ressort"
+          example: "politik"
         4:
           type: string
-          description: 'Sourcetype'
-          example: 'zede'
+          description: "Sourcetype"
+          example: "zede"
         5:
           type: string
-          description: 'Subressort'
-          example: 'deutschland'
+          description: "Subressort"
+          example: "deutschland"
         6:
           type: string
-          description: 'Cluster (series name)'
-          example: 'allesgesagt?'
+          description: "Cluster (series name)"
+          example: "allesgesagt?"
         7:
           type: string
-          description: 'Basename'
-          example: 'index'
+          description: "Basename"
+          example: "index"
         8:
           type: string
-          description: 'Banner-Channel'
-          example: 'politik/deutschland/centerpage'
+          description: "Banner-Channel"
+          example: "politik/deutschland/centerpage"
         9:
           type: string
-          description: 'Date first released'
-          example: '2019-06-12'
+          description: "Date first released"
+          example: "2019-06-12"
 
     TrackingCustomParameter:
       type: object
-      description: 'Custom page parameter'
+      description: "Custom page parameter"
       properties:
         2:
           type: string
-          description: 'IVW-Code'
-          example: 'politik/deutschland/bild-text'
+          description: "IVW-Code"
+          example: "politik/deutschland/bild-text"
         3:
           type: string
-          description: 'Pagination'
-          example: '1/1'
+          description: "Pagination"
+          example: "1/1"
         4:
           type: string
-          description: 'Keywords separated by semicolons'
-          example: 'politik;deutschland'
+          description: "Keywords separated by semicolons"
+          example: "politik;deutschland"
         5:
           type: string
-          description: 'Date last published'
-          example: '2019-06-12 15:21:44.350769+02:00'
+          description: "Date last published"
+          example: "2019-06-12 15:21:44.350769+02:00"
         8:
           type: string
-          description: 'Product-ID'
-          example: 'zede'
+          description: "Product-ID"
+          example: "zede"
         9:
           type: string
-          description: 'Banner-Channel'
-          example: 'politik/deutschland/centerpage'
+          description: "Banner-Channel"
+          example: "politik/deutschland/centerpage"
         10:
           type: string
-          description: 'Banner active (advertising enabled)'
+          description: "Banner active (advertising enabled)"
           enum:
-            - 'yes'
-            - 'no'
-          example: 'yes'
+            - "yes"
+            - "no"
+          example: "yes"
         25:
           type: string
-          description: 'Plattform'
-          example: 'original'
+          description: "Plattform"
+          example: "original"
         26:
           type: string
-          description: 'Detailed Content-Type'
-          example: 'centerpage.centerpage'
+          description: "Detailed Content-Type"
+          example: "centerpage.centerpage"
         28:
           type: string
-          description: 'Access'
+          description: "Access"
           enum:
             - free
             - registration
             - dynamic
             - abo
-          example: 'free'
+          example: "free"
         29:
           type: string
-          description: 'First Click Free'
+          description: "First Click Free"
           enum:
-            - 'yes'
-            - 'no'
+            - "yes"
+            - "no"
             - unfeasible
-          example: 'unfeasible'
+          example: "unfeasible"
         30:
           type: string
-          description: 'Paywall Status'
+          description: "Paywall Status"
           enum:
             - open
             - register
             - metered
             - paid
-          example: 'open'
+          example: "open"
         38:
           type: string
-          description: 'Channels separated by semicolons'
-          example: 'podcast;kultur;film'
+          description: "Channels separated by semicolons"
+          example: "podcast;kultur;film"
 
     CustomClickParameter:
       type: object
-      description: 'Custom click parameter'
+      description: "Custom click parameter"
       properties:
         5:
           type: string
-          description: 'Area'
-          example: 'headed-zplus'
+          description: "Area"
+          example: "headed-zplus"
         6:
           type: string
-          description: 'Row'
-          example: '1'
+          description: "Row"
+          example: "1"
         7:
           type: string
-          description: 'Column'
-          example: '4'
+          description: "Column"
+          example: "4"
         8:
           type: string
-          description: 'Subcolumn'
-          example: 'zon-teaser-standard'
+          description: "Subcolumn"
+          example: "zon-teaser-standard"
 
     AudioConnection:
       type: object
@@ -1237,7 +1237,7 @@ components:
         url:
           type: string
           # format: uri
-          example: 'https://podcasts.apple.com/podcast/id1279335230'
+          example: "https://podcasts.apple.com/podcast/id1279335230"
 
     Audio:
       type: object
@@ -1250,37 +1250,37 @@ components:
         audioType:
           type: string
           enum: [custom, podcast, premium, tts]
-          description: 'type of audio source'
+          description: "type of audio source"
         access:
           type: string
           nullable: true
           enum: [abo, registration, dynamic, null]
-          description: 'DEPRECATED use `entitlements` instead'
+          description: "DEPRECATED use `entitlements` instead"
         entitlements:
-          $ref: '#/components/schemas/ContentEntitlements'
+          $ref: "#/components/schemas/ContentEntitlements"
         color:
           type: string
           nullable: true
-          example: '8ed8a6'
+          example: "8ed8a6"
         duration:
           type: integer
           nullable: true
-          description: 'total duration of the audio in seconds'
+          description: "total duration of the audio in seconds"
         url:
           type: string
           # format: uri
-          description: 'URL directly to the audio source'
-          example: 'https://injector.simplecastaudio.com/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/128/default.mp3?awCollectionId=60989a9e-80b6-4f17-979a-fc949043cf6b&amp;awEpisodeId=0d4af84d-a3b9-4373-8c99-c20fe3c16345'
+          description: "URL directly to the audio source"
+          example: "https://injector.simplecastaudio.com/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/128/default.mp3?awCollectionId=60989a9e-80b6-4f17-979a-fc949043cf6b&amp;awEpisodeId=0d4af84d-a3b9-4373-8c99-c20fe3c16345"
         ad-free-url:
           type: string
           nullable: true
           # format: uri
-          description: 'Adfree URL directly to the audio source'
-          example: 'https://cdn.simplecast.com/audio/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/16a0ad94-096b-42b6-b7a2-c02f15fe9085/default_tc.mp3'
+          description: "Adfree URL directly to the audio source"
+          example: "https://cdn.simplecast.com/audio/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/16a0ad94-096b-42b6-b7a2-c02f15fe9085/default_tc.mp3"
 
     PodcastAudio:
       type: object
-      description: 'Legacy audio object for CenterpageTeaserPodcast'
+      description: "Legacy audio object for CenterpageTeaserPodcast"
       nullable: true
       required:
         - duration
@@ -1289,25 +1289,25 @@ components:
         color:
           type: string
           nullable: true
-          example: '8ed8a6'
+          example: "8ed8a6"
         duration:
           type: string
-          example: '-00:05:23'
+          example: "-00:05:23"
         url:
           type: string
           # format: uri
-          description: 'URL directly to the audio source'
-          example: 'https://injector.simplecastaudio.com/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/128/default.mp3?awCollectionId=60989a9e-80b6-4f17-979a-fc949043cf6b&amp;awEpisodeId=0d4af84d-a3b9-4373-8c99-c20fe3c16345'
+          description: "URL directly to the audio source"
+          example: "https://injector.simplecastaudio.com/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/128/default.mp3?awCollectionId=60989a9e-80b6-4f17-979a-fc949043cf6b&amp;awEpisodeId=0d4af84d-a3b9-4373-8c99-c20fe3c16345"
         ad-free-url:
           type: string
           nullable: true
           # format: uri
-          description: 'Adfree URL directly to the audio source'
-          example: 'https://cdn.simplecast.com/audio/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/16a0ad94-096b-42b6-b7a2-c02f15fe9085/default_tc.mp3'
+          description: "Adfree URL directly to the audio source"
+          example: "https://cdn.simplecast.com/audio/60989a9e-80b6-4f17-979a-fc949043cf6b/episodes/0d4af84d-a3b9-4373-8c99-c20fe3c16345/audio/16a0ad94-096b-42b6-b7a2-c02f15fe9085/default_tc.mp3"
         connections:
           type: array
           items:
-            $ref: '#/components/schemas/AudioConnection'
+            $ref: "#/components/schemas/AudioConnection"
 
     Volume:
       type: object
@@ -1318,15 +1318,15 @@ components:
         - number
       properties:
         volumeImage:
-          $ref: '#/components/schemas/Image'
+          $ref: "#/components/schemas/Image"
         volumeLabel:
           type: string
-          description: 'label for for volume'
-          example: 'DIE ZEIT 12/2023'
+          description: "label for for volume"
+          example: "DIE ZEIT 12/2023"
         volumeColor:
           type: string
-          description: 'Hex value of background color of the volume without #'
-          example: '2e8b57'
+          description: "Hex value of background color of the volume without #"
+          example: "2e8b57"
           minLength: 6
           maxLength: 6
           nullable: true
@@ -1334,30 +1334,30 @@ components:
           type: string
           nullable: true
           # format: uri
-          description: 'An URL to the volume'
-          example: 'https://www.zeit.de/2023/12/index'
+          description: "An URL to the volume"
+          example: "https://www.zeit.de/2023/12/index"
         year:
           type: integer
         number:
           type: integer
         datePublished:
           type: string
-          description: 'Formatted date of publication'
-          example: '25. Januar 2024'
+          description: "Formatted date of publication"
+          example: "25. Januar 2024"
 
     CenterpageElement:
       required:
         - type
       properties:
         id:
-          $ref: '#/components/schemas/CenterpageElementId'
+          $ref: "#/components/schemas/CenterpageElementId"
         type:
-          $ref: '#/components/schemas/CenterpageElementType'
+          $ref: "#/components/schemas/CenterpageElementType"
 
     CenterpageTeaserBase:
-      description: 'A teaser module references/represents a content object (article, video, etc.)'
+      description: "A teaser module references/represents a content object (article, video, etc.)"
       allOf:
-        - $ref: '#/components/schemas/CenterpageElement'
+        - $ref: "#/components/schemas/CenterpageElement"
         - required:
             - layout
             - title
@@ -1399,53 +1399,53 @@ components:
                 - zon-teaser-standard-compact
                 - zon-teaser-stripe
                 - zon-teaser-wide
-              description: 'How to display this teaser (e.g large/small)'
+              description: "How to display this teaser (e.g large/small)"
             title:
               type: string
-              description: 'Main title of the article'
-              example: 'My Article Title'
+              description: "Main title of the article"
+              example: "My Article Title"
             supertitle:
               type: string
               nullable: true
-              description: 'The supertitle/kicker are 1-2 keywords that denote the context/topic of the article'
-              example: 'Olympics'
+              description: "The supertitle/kicker are 1-2 keywords that denote the context/topic of the article"
+              example: "Olympics"
             text:
               type: string
               nullable: true
-              description: 'Teaser text is a few sentences that summarize/introduce the article'
+              description: "Teaser text is a few sentences that summarize/introduce the article"
               example: "This is the teaser text\nIt may contain line breaks."
             url:
               type: string
               # format: uri
-              example: 'https://www.zeit.de/my/article'
+              example: "https://www.zeit.de/my/article"
             uuid:
-              $ref: '#/components/schemas/UUID'
+              $ref: "#/components/schemas/UUID"
             image:
-              $ref: '#/components/schemas/Image'
+              $ref: "#/components/schemas/Image"
             authorImage:
-              $ref: '#/components/schemas/Image'
+              $ref: "#/components/schemas/Image"
             dateFirstPublished:
               type: string
               format: date-time
-              description: 'Timestamp when the article was published initially'
-              example: '2019-12-31T13:12:00Z'
+              description: "Timestamp when the article was published initially"
+              example: "2019-12-31T13:12:00Z"
             dateLastPublishedSemantic:
               type: string
               format: date-time
-              description: 'Timestamp of the most recent semantic/relevant update to the article'
-              example: '2020-01-01T13:12:00Z'
+              description: "Timestamp of the most recent semantic/relevant update to the article"
+              example: "2020-01-01T13:12:00Z"
             date:
               type: string
               nullable: true
-              description: 'Human readable relative or absolute date'
-              example: 'Vor 3 Stunden'
+              description: "Human readable relative or absolute date"
+              example: "Vor 3 Stunden"
             entitlements:
-              $ref: '#/components/schemas/ContentEntitlements'
+              $ref: "#/components/schemas/ContentEntitlements"
             byline:
               type: string
               nullable: true
-              description: 'Ready-made string that contains the author names and maybe some more information like the article genre'
-              example: 'Eine Glosse von August Weythershaußen, Erzgebirge'
+              description: "Ready-made string that contains the author names and maybe some more information like the article genre"
+              example: "Eine Glosse von August Weythershaußen, Erzgebirge"
             badges:
               type: array
               items:
@@ -1455,36 +1455,36 @@ components:
                   - livestream
                   - zplus
                   - zplus-spiele
-              description: 'List of icon IDs that should be displayed for this teaser'
-              example: ['zplus']
+              description: "List of icon IDs that should be displayed for this teaser"
+              example: ["zplus"]
             label:
               type: string
               # ZON-6127: disabled until the implementation catches up:
               # enum:
               #   - Anzeige
               #   - Verlagsangebot
-              description: 'Additional label to mark teasers with corporate advertising'
-              example: 'Verlagsangebot'
+              description: "Additional label to mark teasers with corporate advertising"
+              example: "Verlagsangebot"
             audioInfo:
-              $ref: '#/components/schemas/Audio'
+              $ref: "#/components/schemas/Audio"
             volume:
-              $ref: '#/components/schemas/Volume'
+              $ref: "#/components/schemas/Volume"
             comments:
               type: object
               properties:
                 count:
                   type: string
-                  description: 'Count of comments for this article'
-                  example: '18.345'
+                  description: "Count of comments for this article"
+                  example: "18.345"
                 label:
                   type: string
-                  description: 'Descriptive label for count of comments for this article'
-                  example: '18.345 Kommentare'
+                  description: "Descriptive label for count of comments for this article"
+                  example: "18.345 Kommentare"
                 url:
                   type: string
                   # format: uri
-                  description: 'URL directly to the comment area of the article'
-                  example: 'https://www.zeit.de/my/article#comments'
+                  description: "URL directly to the comment area of the article"
+                  example: "https://www.zeit.de/my/article#comments"
             bookmarkable:
               type: boolean
               example: true
@@ -1492,7 +1492,7 @@ components:
               type: object
               properties:
                 customClickParameter:
-                  $ref: '#/components/schemas/CustomClickParameter'
+                  $ref: "#/components/schemas/CustomClickParameter"
             liveblogPosts:
               nullable: true
               type: array
@@ -1501,34 +1501,34 @@ components:
                 properties:
                   title:
                     type: string
-                    description: 'Title of the liveblog entry'
-                    example: 'Ereignisse haben stattgefunden'
+                    description: "Title of the liveblog entry"
+                    example: "Ereignisse haben stattgefunden"
                   url:
                     type: string
                     # format: uri
-                    description: 'URL directly to the liveblog entry'
-                    example: 'https://www.zeit.de/politik/ausland/2023-12/news-live#tickaroo_event_id=xxx'
+                    description: "URL directly to the liveblog entry"
+                    example: "https://www.zeit.de/politik/ausland/2023-12/news-live#tickaroo_event_id=xxx"
                   date:
                     type: string
-                    description: 'A nice description of the datetime the liveblog entry was posted'
-                    example: 'Gestern, 16:45 Uhr'
-              description: 'List of liveblog posts that should be displayed for this teaser'
+                    description: "A nice description of the datetime the liveblog entry was posted"
+                    example: "Gestern, 16:45 Uhr"
+              description: "List of liveblog posts that should be displayed for this teaser"
 
     CenterpageTeaser:
-      description: 'A teaser module references/represents an article content object'
+      description: "A teaser module references/represents an article content object"
       allOf:
-        - $ref: '#/components/schemas/CenterpageTeaserBase'
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
         - properties:
             type:
               type: string
               enum:
                 - teaser
-              example: 'teaser'
+              example: "teaser"
 
     CenterpageTeaserGallery:
-      description: 'A teaser module references/represents a gallery content object'
+      description: "A teaser module references/represents a gallery content object"
       allOf:
-        - $ref: '#/components/schemas/CenterpageTeaserBase'
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
         - required:
             - gallery
           properties:
@@ -1536,19 +1536,19 @@ components:
               type: string
               enum:
                 - teaser-gallery
-              example: 'teaser-gallery'
+              example: "teaser-gallery"
             gallery:
               type: object
               properties:
                 label:
                   type: string
-                  description: 'Label to display gallery content'
-                  example: '18 Bilder'
+                  description: "Label to display gallery content"
+                  example: "18 Bilder"
 
     CenterpageTeaserVideo:
-      description: 'A teaser module references/represents a video content object'
+      description: "A teaser module references/represents a video content object"
       allOf:
-        - $ref: '#/components/schemas/CenterpageTeaserBase'
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
         - required:
             - video
           properties:
@@ -1556,13 +1556,13 @@ components:
               type: string
               enum:
                 - teaser-video
-              example: 'teaser-video'
+              example: "teaser-video"
             video:
               type: object
               properties:
                 id:
                   type: string
-                  example: '6194436097001'
+                  example: "6194436097001"
                 hasAdvertisement:
                   type: boolean
                 # provider: "brightcove"
@@ -1571,9 +1571,9 @@ components:
                 # series: serienname
 
     CenterpageTeaserPodcast:
-      description: 'A teaser module references/represents an article content object with audio (simplecast podcast)'
+      description: "A teaser module references/represents an article content object with audio (simplecast podcast)"
       allOf:
-        - $ref: '#/components/schemas/CenterpageTeaserBase'
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
         - required:
             - audio
             - audioInfo
@@ -1582,24 +1582,24 @@ components:
               type: string
               enum:
                 - teaser-podcast
-              example: 'teaser-podcast'
+              example: "teaser-podcast"
             audio:
-              $ref: '#/components/schemas/PodcastAudio'
+              $ref: "#/components/schemas/PodcastAudio"
             audioInfo:
-              $ref: '#/components/schemas/Audio'
+              $ref: "#/components/schemas/Audio"
             episodeImage:
-              $ref: '#/components/schemas/Image'
+              $ref: "#/components/schemas/Image"
             seriesImage:
-              $ref: '#/components/schemas/Image'
+              $ref: "#/components/schemas/Image"
             seriesUrl:
               type: string
-              example: 'https://www.zeit.de/serie/alles-gesagt'
-              description: 'An URL to the series if podcast is episode of it'
+              example: "https://www.zeit.de/serie/alles-gesagt"
+              description: "An URL to the series if podcast is episode of it"
 
     CenterpageTeaserAudio:
-      description: 'A teaser module references/represents an article content object with premium audio'
+      description: "A teaser module references/represents an article content object with premium audio"
       allOf:
-        - $ref: '#/components/schemas/CenterpageTeaserBase'
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
         - required:
             - audioInfo
           properties:
@@ -1607,16 +1607,16 @@ components:
               type: string
               enum:
                 - teaser-audio
-              example: 'teaser-audio'
+              example: "teaser-audio"
             audioInfo:
-              $ref: '#/components/schemas/Audio'
+              $ref: "#/components/schemas/Audio"
             volume:
-              $ref: '#/components/schemas/Volume'
+              $ref: "#/components/schemas/Volume"
 
     CenterpageModuleHTML:
-      description: 'A non-native module that should be displayed via a web view'
+      description: "A non-native module that should be displayed via a web view"
       allOf:
-        - $ref: '#/components/schemas/CenterpageElement'
+        - $ref: "#/components/schemas/CenterpageElement"
         - required:
             - content
           properties:
@@ -1624,16 +1624,16 @@ components:
               type: string
               enum:
                 - html
-              example: 'html'
+              example: "html"
             content:
               type: string
               format: html
-              example: '<embed>Anything can happen here.</embed>'
+              example: "<embed>Anything can happen here.</embed>"
 
     CenterpageTeaserAuthor:
-      description: 'A teaser module references/represents an author content object'
+      description: "A teaser module references/represents an author content object"
       allOf:
-        - $ref: '#/components/schemas/CenterpageTeaserBase'
+        - $ref: "#/components/schemas/CenterpageTeaserBase"
         - properties:
             type:
               type: string
@@ -1641,9 +1641,9 @@ components:
                 - teaser-author
 
     CenterpageAreaBase:
-      description: 'CenterPages contain areas, which in turn contain modules'
+      description: "CenterPages contain areas, which in turn contain modules"
       allOf:
-        - $ref: '#/components/schemas/CenterpageElement'
+        - $ref: "#/components/schemas/CenterpageElement"
         - required:
             - layout
             - items
@@ -1654,33 +1654,33 @@ components:
               type: string
               nullable: true
               # format: uri
-              description: 'A section often links to topic pages etc.'
-              example: 'https://www.zeit.de/thema/hamburg'
+              description: "A section often links to topic pages etc."
+              example: "https://www.zeit.de/thema/hamburg"
             linkedUuid:
-              $ref: '#/components/schemas/UUID'
-              description: 'The UUID of the link, if given'
-              example: '977ff669-b044-4a1b-b444-00c1d717905f'
+              $ref: "#/components/schemas/UUID"
+              description: "The UUID of the link, if given"
+              example: "977ff669-b044-4a1b-b444-00c1d717905f"
             title:
               type: string
               nullable: true
-              example: 'This is a simple title'
+              example: "This is a simple title"
             supertitle:
               type: string
               nullable: true
-              example: 'Das Beste aus Z+'
+              example: "Das Beste aus Z+"
             items:
               type: array
             topiclinks:
               nullable: true
               items:
-                $ref: '#/components/schemas/CenterpageAreaTopicLink'
+                $ref: "#/components/schemas/CenterpageAreaTopicLink"
             readmore:
               type: string
               nullable: true
-              example: 'Mehr zum Thema Simple Title'
+              example: "Mehr zum Thema Simple Title"
 
     CenterpageAreaTopicLink:
-      description: 'Links to topicpage'
+      description: "Links to topicpage"
       type: object
       required:
         - label
@@ -1688,20 +1688,20 @@ components:
       properties:
         label:
           type: string
-          example: 'Hongkong'
+          example: "Hongkong"
         link:
           type: string
           example: https://www.zeit.de/schlagworte/orte/hongkong/index"
 
     CenterpageRegion:
       allOf:
-        - $ref: '#/components/schemas/CenterpageAreaBase'
+        - $ref: "#/components/schemas/CenterpageAreaBase"
         - properties:
             type:
               type: string
               enum:
                 - region
-              example: 'region'
+              example: "region"
             layout:
               type: string
               enum:
@@ -1712,17 +1712,17 @@ components:
             items:
               type: array
               items:
-                $ref: '#/components/schemas/CenterpageArea'
+                $ref: "#/components/schemas/CenterpageArea"
 
     CenterpageArea:
       allOf:
-        - $ref: '#/components/schemas/CenterpageAreaBase'
+        - $ref: "#/components/schemas/CenterpageAreaBase"
         - properties:
             type:
               type: string
               enum:
                 - area
-              example: 'area'
+              example: "area"
             layout:
               type: string
               enum:
@@ -1746,33 +1746,33 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/CenterpageTeaser'
-                  - $ref: '#/components/schemas/CenterpageTeaserAuthor'
-                  - $ref: '#/components/schemas/CenterpageTeaserGallery'
-                  - $ref: '#/components/schemas/CenterpageTeaserVideo'
-                  - $ref: '#/components/schemas/CenterpageTeaserPodcast'
-                  - $ref: '#/components/schemas/CenterpageTeaserAudio'
-                  - $ref: '#/components/schemas/CenterpageModuleHTML'
-                  - $ref: '#/components/schemas/CenterpageExtra'
+                  - $ref: "#/components/schemas/CenterpageTeaser"
+                  - $ref: "#/components/schemas/CenterpageTeaserAuthor"
+                  - $ref: "#/components/schemas/CenterpageTeaserGallery"
+                  - $ref: "#/components/schemas/CenterpageTeaserVideo"
+                  - $ref: "#/components/schemas/CenterpageTeaserPodcast"
+                  - $ref: "#/components/schemas/CenterpageTeaserAudio"
+                  - $ref: "#/components/schemas/CenterpageModuleHTML"
+                  - $ref: "#/components/schemas/CenterpageExtra"
                 discriminator:
                   propertyName: type
                   mapping:
-                    teaser: '#/components/schemas/CenterpageTeaser'
-                    teaser-author: '#/components/schemas/CenterpageTeaserAuthor'
-                    teaser-gallery: '#/components/schemas/CenterpageTeaserGallery'
-                    teaser-video: '#/components/schemas/CenterpageTeaserVideo'
-                    teaser-podcast: '#/components/schemas/CenterpageTeaserPodcast'
-                    teaser-audio: '#/components/schemas/CenterpageTeaserAudio'
-                    html: '#/components/schemas/CenterpageModuleHTML'
-                    cpextra: '#/components/schemas/CenterpageExtra'
+                    teaser: "#/components/schemas/CenterpageTeaser"
+                    teaser-author: "#/components/schemas/CenterpageTeaserAuthor"
+                    teaser-gallery: "#/components/schemas/CenterpageTeaserGallery"
+                    teaser-video: "#/components/schemas/CenterpageTeaserVideo"
+                    teaser-podcast: "#/components/schemas/CenterpageTeaserPodcast"
+                    teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
+                    html: "#/components/schemas/CenterpageModuleHTML"
+                    cpextra: "#/components/schemas/CenterpageExtra"
             trackingData:
               type: object
               properties:
                 customClickParameter:
-                  $ref: '#/components/schemas/CustomClickParameter'
+                  $ref: "#/components/schemas/CustomClickParameter"
 
     CenterpageAdplace:
-      description: 'Placeholder for advertisement'
+      description: "Placeholder for advertisement"
       required:
         - device
         - tile
@@ -1782,7 +1782,7 @@ components:
           enum:
             - adplace
         tile:
-          description: 'IQD ad tile number'
+          description: "IQD ad tile number"
           type: string
         device:
           type: string
@@ -1791,18 +1791,18 @@ components:
             - mobile
 
     CenterpageHeader:
-      description: 'Header for native centerpages'
+      description: "Header for native centerpages"
       required:
         - type
       properties:
         id:
-          $ref: '#/components/schemas/CenterpageElementId'
+          $ref: "#/components/schemas/CenterpageElementId"
         type:
           type: string
           enum:
             - header
         image:
-          $ref: '#/components/schemas/Image'
+          $ref: "#/components/schemas/Image"
         supertitle:
           type: string
           nullable: true
@@ -1811,13 +1811,13 @@ components:
           nullable: true
 
     CenterpageMarkup:
-      description: 'A list of text'
+      description: "A list of text"
       required:
         - type
         - text
       properties:
         id:
-          $ref: '#/components/schemas/CenterpageElementId'
+          $ref: "#/components/schemas/CenterpageElementId"
         type:
           type: string
           enum:
@@ -1828,19 +1828,19 @@ components:
           type: string
 
     CenterpageExtra:
-      description: 'CPExtra: additional content block for centerpages that can contain anything'
+      description: "CPExtra: additional content block for centerpages that can contain anything"
       required:
         - type
         - cpextra
       properties:
         id:
-          $ref: '#/components/schemas/CenterpageElementId'
+          $ref: "#/components/schemas/CenterpageElementId"
         type:
           type: string
           enum:
             - cpextra
         cpextra:
-          description: 'The content type this CPExtra represents'
+          description: "The content type this CPExtra represents"
           type: string
 
     TabBase:
@@ -1853,13 +1853,13 @@ components:
       properties:
         id:
           type: string
-          description: 'ID of the tab'
-          example: 'justsomeuniquestring'
+          description: "ID of the tab"
+          example: "justsomeuniquestring"
         title:
           type: string
           minLength: 1
           maxLength: 15
-          example: 'Start'
+          example: "Start"
         type:
           type: string
           enum:
@@ -1871,81 +1871,81 @@ components:
           properties:
             ios:
               type: string
-              description: 'SF Symbol name'
-              example: 'bookmark'
+              description: "SF Symbol name"
+              example: "bookmark"
             android:
               type: string
-              description: 'Material Design Icon name'
-              example: 'bookmarks'
+              description: "Material Design Icon name"
+              example: "bookmarks"
         visible-from:
           type: string
-          description: 'Time when the tab becomes visible in the app'
-          example: 'DAY=MO;TIME=00:00:00'
+          description: "Time when the tab becomes visible in the app"
+          example: "DAY=MO;TIME=00:00:00"
         visible-to:
           type: string
-          description: 'Time when the tab becomes invisible in the app'
-          example: 'DAY=FR;TIME=16:00:00'
+          description: "Time when the tab becomes invisible in the app"
+          example: "DAY=FR;TIME=16:00:00"
         menu-left:
           type: string
-          description: 'The ID of the menu, which should be shown in the upper left of a tab.'
-          example: 'navigation_main'
+          description: "The ID of the menu, which should be shown in the upper left of a tab."
+          example: "navigation_main"
         menu-right:
           type: string
-          description: 'The ID of the menu, which should be shown in the upper right of a tab.'
-          example: 'navigation_account'
+          description: "The ID of the menu, which should be shown in the upper right of a tab."
+          example: "navigation_account"
         items:
           type: array
 
     TabCenterpage:
       allOf:
-        - $ref: '#/components/schemas/TabBase'
+        - $ref: "#/components/schemas/TabBase"
         - properties:
             type:
               type: string
               enum:
                 - tab-centerpage
-              example: 'tab-centerpage'
+              example: "tab-centerpage"
             items:
               type: array
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/MenuItemNative'
-                  - $ref: '#/components/schemas/MenuItemWeb'
-                  - $ref: '#/components/schemas/MenuItemTabStart'
+                  - $ref: "#/components/schemas/MenuItemNative"
+                  - $ref: "#/components/schemas/MenuItemWeb"
+                  - $ref: "#/components/schemas/MenuItemTabStart"
                 discriminator:
                   propertyName: type
                   mapping:
-                    menu-item-native: '#/components/schemas/MenuItemNative'
-                    menu-item-web: '#/components/schemas/MenuItemWeb'
-                    menu-item-tab-start: '#/components/schemas/MenuItemTabStart'
+                    menu-item-native: "#/components/schemas/MenuItemNative"
+                    menu-item-web: "#/components/schemas/MenuItemWeb"
+                    menu-item-tab-start: "#/components/schemas/MenuItemTabStart"
 
     TabStory:
       allOf:
-        - $ref: '#/components/schemas/TabBase'
+        - $ref: "#/components/schemas/TabBase"
         - properties:
             type:
               type: string
               enum:
                 - tab-story
-              example: 'tab-story'
+              example: "tab-story"
             items:
               type: array
               items:
-                $ref: '#/components/schemas/MenuItemNative'
+                $ref: "#/components/schemas/MenuItemNative"
 
     TabMenu:
       allOf:
-        - $ref: '#/components/schemas/TabBase'
+        - $ref: "#/components/schemas/TabBase"
         - properties:
             type:
               type: string
               enum:
                 - tab-menu
-              example: 'tab-menu'
+              example: "tab-menu"
             items:
               type: array
               items:
-                $ref: '#/components/schemas/MenuSection'
+                $ref: "#/components/schemas/MenuSection"
 
     MenuBase:
       required:
@@ -1957,11 +1957,11 @@ components:
       properties:
         id:
           type: string
-          description: 'ID of the navigation'
-          example: 'justsomeuniquestring'
+          description: "ID of the navigation"
+          example: "justsomeuniquestring"
         title:
           type: string
-          example: 'Menü'
+          example: "Menü"
         type:
           type: string
           enum:
@@ -1972,51 +1972,51 @@ components:
           properties:
             ios:
               type: string
-              description: 'SF Symbol name'
-              example: 'bookmark'
+              description: "SF Symbol name"
+              example: "bookmark"
             android:
               type: string
-              description: 'Material Design Icon name'
-              example: 'bookmarks'
+              description: "Material Design Icon name"
+              example: "bookmarks"
         items:
           type: array
 
     ContentMenu:
       allOf:
-        - $ref: '#/components/schemas/MenuBase'
+        - $ref: "#/components/schemas/MenuBase"
         - properties:
             type:
               type: string
               enum:
                 - content-menu
-              example: 'content-menu'
+              example: "content-menu"
             items:
               type: array
               items:
-                $ref: '#/components/schemas/MenuSection'
+                $ref: "#/components/schemas/MenuSection"
 
     UserMenu:
       allOf:
-        - $ref: '#/components/schemas/MenuBase'
+        - $ref: "#/components/schemas/MenuBase"
         - properties:
             type:
               type: string
               enum:
                 - user-menu
-              example: 'user-menu'
+              example: "user-menu"
             items:
               type: array
               items:
-                $ref: '#/components/schemas/MenuSection'
+                $ref: "#/components/schemas/MenuSection"
 
     MenuSection:
       properties:
         id:
           type: string
-          example: 'menu-section-1'
+          example: "menu-section-1"
         title:
           type: string
-          example: 'My section'
+          example: "My section"
         split:
           type: boolean
           example: false
@@ -2030,21 +2030,21 @@ components:
           type: array
           items:
             oneOf:
-              - $ref: '#/components/schemas/MenuItemNative'
-              - $ref: '#/components/schemas/MenuItemApp'
-              - $ref: '#/components/schemas/MenuItemWeb'
-              - $ref: '#/components/schemas/MenuItemBrowser'
-              - $ref: '#/components/schemas/MenuItemSubMenu'
-              - $ref: '#/components/schemas/MenuItemTabStart'
+              - $ref: "#/components/schemas/MenuItemNative"
+              - $ref: "#/components/schemas/MenuItemApp"
+              - $ref: "#/components/schemas/MenuItemWeb"
+              - $ref: "#/components/schemas/MenuItemBrowser"
+              - $ref: "#/components/schemas/MenuItemSubMenu"
+              - $ref: "#/components/schemas/MenuItemTabStart"
             discriminator:
               propertyName: type
               mapping:
-                menu-item-native: '#/components/schemas/MenuItemNative'
-                menu-item-app: '#/components/schemas/MenuItemApp'
-                menu-item-web: '#/components/schemas/MenuItemWeb'
-                menu-item-browser: '#/components/schemas/MenuItemBrowser'
-                menu-item-submenu: '#/components/schemas/MenuItemSubMenu'
-                menu-item-tab-start: '#/components/schemas/MenuItemTabStart'
+                menu-item-native: "#/components/schemas/MenuItemNative"
+                menu-item-app: "#/components/schemas/MenuItemApp"
+                menu-item-web: "#/components/schemas/MenuItemWeb"
+                menu-item-browser: "#/components/schemas/MenuItemBrowser"
+                menu-item-submenu: "#/components/schemas/MenuItemSubMenu"
+                menu-item-tab-start: "#/components/schemas/MenuItemTabStart"
 
     MenuItemBase:
       required:
@@ -2054,10 +2054,10 @@ components:
       properties:
         id:
           type: string
-          example: 'menu-entry1'
+          example: "menu-entry1"
         title:
           type: string
-          example: 'Menu Entry Title'
+          example: "Menu Entry Title"
         type:
           type: string
           enum:
@@ -2072,16 +2072,16 @@ components:
           properties:
             ios:
               type: string
-              description: 'SF Symbol name'
-              example: 'bookmark'
+              description: "SF Symbol name"
+              example: "bookmark"
             android:
               type: string
-              description: 'Material Design Icon name'
-              example: 'bookmarks'
+              description: "Material Design Icon name"
+              example: "bookmarks"
 
     MenuItemNative:
       allOf:
-        - $ref: '#/components/schemas/MenuItemBase'
+        - $ref: "#/components/schemas/MenuItemBase"
         - required:
             - source
           properties:
@@ -2089,13 +2089,13 @@ components:
               type: string
               enum:
                 - menu-item-native
-              example: 'menu-item-native'
+              example: "menu-item-native"
             source:
-              $ref: '#/components/schemas/UUID'
+              $ref: "#/components/schemas/UUID"
 
     MenuItemApp:
       allOf:
-        - $ref: '#/components/schemas/MenuItemBase'
+        - $ref: "#/components/schemas/MenuItemBase"
         - required:
             - targetId
           properties:
@@ -2103,62 +2103,62 @@ components:
               type: string
               enum:
                 - menu-item-app
-              example: 'menu-item-app'
+              example: "menu-item-app"
             targetId:
               type: string
-              example: 'some-app-id'
+              example: "some-app-id"
 
     MenuItemWeb:
       allOf:
-        - $ref: '#/components/schemas/MenuItemBase'
+        - $ref: "#/components/schemas/MenuItemBase"
         - required:
             - url
           properties:
             url:
               type: string
               # format: uri
-              example: 'https://www.zeit.de/some/webviewurl'
+              example: "https://www.zeit.de/some/webviewurl"
             type:
               type: string
               enum:
                 - menu-item-web
-              example: 'menu-item-web'
+              example: "menu-item-web"
 
     MenuItemBrowser:
       allOf:
-        - $ref: '#/components/schemas/MenuItemBase'
+        - $ref: "#/components/schemas/MenuItemBase"
         - required:
             - url
           properties:
             url:
               type: string
               # format: uri
-              example: 'https://www.zeit.de/some/browserurl'
+              example: "https://www.zeit.de/some/browserurl"
             type:
               type: string
               enum:
                 - menu-item-browser
-              example: 'menu-item-browser'
+              example: "menu-item-browser"
 
     MenuItemTabStart:
       allOf:
-        - $ref: '#/components/schemas/MenuItemBase'
+        - $ref: "#/components/schemas/MenuItemBase"
         - required:
             - url
           properties:
             url:
               type: string
               # format: uri
-              example: 'https://www.zeit.de/some/webviewurl'
+              example: "https://www.zeit.de/some/webviewurl"
             type:
               type: string
               enum:
                 - menu-item-tab-start
-              example: 'menu-item-tab-start'
+              example: "menu-item-tab-start"
 
     MenuItemSubMenu:
       allOf:
-        - $ref: '#/components/schemas/MenuItemBase'
+        - $ref: "#/components/schemas/MenuItemBase"
         - required:
             - items
           properties:
@@ -2170,17 +2170,17 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/MenuItemNative'
-                  - $ref: '#/components/schemas/MenuItemApp'
-                  - $ref: '#/components/schemas/MenuItemWeb'
-                  - $ref: '#/components/schemas/MenuItemBrowser'
+                  - $ref: "#/components/schemas/MenuItemNative"
+                  - $ref: "#/components/schemas/MenuItemApp"
+                  - $ref: "#/components/schemas/MenuItemWeb"
+                  - $ref: "#/components/schemas/MenuItemBrowser"
                 discriminator:
                   propertyName: type
                   mapping:
-                    menu-item-native: '#/components/schemas/MenuItemNative'
-                    menu-item-app: '#/components/schemas/MenuItemApp'
-                    menu-item-web: '#/components/schemas/MenuItemWeb'
-                    menu-item-browser: '#/components/schemas/MenuItemBrowser'
+                    menu-item-native: "#/components/schemas/MenuItemNative"
+                    menu-item-app: "#/components/schemas/MenuItemApp"
+                    menu-item-web: "#/components/schemas/MenuItemWeb"
+                    menu-item-browser: "#/components/schemas/MenuItemBrowser"
 
     AppStoreType:
       type: string

--- a/docs/api/package-lock.json
+++ b/docs/api/package-lock.json
@@ -1,1250 +1,1250 @@
 {
-  "name": "swagger-deployment",
-  "version": "1.0.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "swagger-deployment",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "swagger-cli": "^4.0.4"
-      },
-      "devDependencies": {
-        "@zeitonline/prettier-config": "^1.1.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
-      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "node_modules/@apidevtools/openapi-schemas": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.4.tgz",
-      "integrity": "sha512-ob5c4UiaMYkb24pNhvfSABShAwpREvUGCkqjiz/BX9gKZ32y/S22M+ALIHftTAuv9KsFVSpVdIDzi9ZzFh5TCA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
-    },
-    "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
-      "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^4.2.3"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
-    "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
-      "integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "acorn": "^8.9.0"
-      }
-    },
-    "node_modules/@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@zeitonline/prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@zeitonline/prettier-config/-/prettier-config-1.1.0.tgz",
-      "integrity": "sha512-jHU828Wt4tDgBdTLj68BnrtrOBlsX8EsSP80ZIPg4wocgBK0xnkYtqIte8CkFfkKJAZBC1cRsQGtsrHM5lkf9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-plugin-svelte": "^3.2.7"
-      },
-      "peerDependencies": {
-        "prettier": "^3.2.0"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-      "dependencies": {
-        "@types/color-name": "^1.1.1",
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/axobject-query": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/esm-env": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
-      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/esrap": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
-      "integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-reference": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
-      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.6"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/locate-character": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-plugin-svelte": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
-      "integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "prettier": "^3.0.0",
-        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/svelte": {
-      "version": "5.25.8",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.25.8.tgz",
-      "integrity": "sha512-yRmjmT5rgCZUMfCKS5varGlSe/nQyr2oClyIirbBChfTFc00YjVAyVWo1zOH74La3hi5KRSkNJKncyJ04PwIYA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
-        "@types/estree": "^1.0.5",
-        "acorn": "^8.12.1",
-        "aria-query": "^5.3.1",
-        "axobject-query": "^4.1.0",
-        "clsx": "^2.1.1",
-        "esm-env": "^1.2.1",
-        "esrap": "^1.4.6",
-        "is-reference": "^3.0.3",
-        "locate-character": "^3.0.0",
-        "magic-string": "^0.30.11",
-        "zimmerframe": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/swagger-cli": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/swagger-cli/-/swagger-cli-4.0.4.tgz",
-      "integrity": "sha512-Cp8YYuLny3RJFQ4CvOBTaqmOOgYsem52dPx1xM5S4EUWFblIh2Q8atppMZvXKUr1e9xH5RwipYpmdUzdPcxWcA==",
-      "dependencies": {
-        "@apidevtools/swagger-cli": "4.0.4"
-      },
-      "bin": {
-        "swagger-cli": "swagger-cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/swagger-cli/node_modules/@apidevtools/swagger-cli": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-cli/-/swagger-cli-4.0.4.tgz",
-      "integrity": "sha512-hdDT3B6GLVovCsRZYDi3+wMcB1HfetTU20l2DC8zD3iFRNMC6QNAZG5fo/6PYeHWBEv7ri4MvnlKodhNB0nt7g==",
-      "dependencies": {
-        "@apidevtools/swagger-parser": "^10.0.1",
-        "chalk": "^4.1.0",
-        "js-yaml": "^3.14.0",
-        "yargs": "^15.4.1"
-      },
-      "bin": {
-        "swagger-cli": "bin/swagger-cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-    },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
-    },
-    "node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/z-schema": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
-      "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.6.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^2.7.1"
-      }
-    },
-    "node_modules/zimmerframe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
-      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    }
-  },
-  "dependencies": {
-    "@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
-      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "@apidevtools/openapi-schemas": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.4.tgz",
-      "integrity": "sha512-ob5c4UiaMYkb24pNhvfSABShAwpREvUGCkqjiz/BX9gKZ32y/S22M+ALIHftTAuv9KsFVSpVdIDzi9ZzFh5TCA=="
-    },
-    "@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
-    },
-    "@apidevtools/swagger-parser": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
-      "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
-      "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^4.2.3"
-      }
-    },
-    "@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "peer": true
-    },
-    "@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "peer": true
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
-      "peer": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
-    "@sveltejs/acorn-typescript": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
-      "integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {}
-    },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-    },
-    "@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
-      "peer": true
-    },
-    "@zeitonline/prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@zeitonline/prettier-config/-/prettier-config-1.1.0.tgz",
-      "integrity": "sha512-jHU828Wt4tDgBdTLj68BnrtrOBlsX8EsSP80ZIPg4wocgBK0xnkYtqIte8CkFfkKJAZBC1cRsQGtsrHM5lkf9w==",
-      "dev": true,
-      "requires": {
-        "prettier-plugin-svelte": "^3.2.7"
-      }
-    },
-    "acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true,
-      "peer": true
-    },
-    "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "ansi-styles": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-      "requires": {
-        "@types/color-name": "^1.1.1",
-        "color-convert": "^2.0.1"
-      }
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
-      "peer": true
-    },
-    "axobject-query": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
-      "peer": true
-    },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-    },
-    "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-    },
-    "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      }
-    },
-    "cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
-      "peer": true
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "esm-env": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
-      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
-      "peer": true
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    },
-    "esrap": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
-      "integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      }
-    },
-    "find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "requires": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      }
-    },
-    "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "is-reference": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
-      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/estree": "^1.0.6"
-      }
-    },
-    "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
-    "locate-character": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
-      "peer": true
-    },
-    "locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "requires": {
-        "p-locate": "^4.1.0"
-      }
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
-    "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "requires": {
-        "p-try": "^2.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "requires": {
-        "p-limit": "^2.2.0"
-      }
-    },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-    },
-    "path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-    },
-    "prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
-      "dev": true,
-      "peer": true
-    },
-    "prettier-plugin-svelte": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
-      "integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
-      "dev": true,
-      "requires": {}
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "requires": {
-        "ansi-regex": "^5.0.0"
-      }
-    },
-    "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
-    },
-    "svelte": {
-      "version": "5.25.8",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.25.8.tgz",
-      "integrity": "sha512-yRmjmT5rgCZUMfCKS5varGlSe/nQyr2oClyIirbBChfTFc00YjVAyVWo1zOH74La3hi5KRSkNJKncyJ04PwIYA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@ampproject/remapping": "^2.3.0",
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
-        "@types/estree": "^1.0.5",
-        "acorn": "^8.12.1",
-        "aria-query": "^5.3.1",
-        "axobject-query": "^4.1.0",
-        "clsx": "^2.1.1",
-        "esm-env": "^1.2.1",
-        "esrap": "^1.4.6",
-        "is-reference": "^3.0.3",
-        "locate-character": "^3.0.0",
-        "magic-string": "^0.30.11",
-        "zimmerframe": "^1.1.2"
-      }
-    },
-    "swagger-cli": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/swagger-cli/-/swagger-cli-4.0.4.tgz",
-      "integrity": "sha512-Cp8YYuLny3RJFQ4CvOBTaqmOOgYsem52dPx1xM5S4EUWFblIh2Q8atppMZvXKUr1e9xH5RwipYpmdUzdPcxWcA==",
-      "requires": {
-        "@apidevtools/swagger-cli": "4.0.4"
-      },
-      "dependencies": {
-        "@apidevtools/swagger-cli": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/@apidevtools/swagger-cli/-/swagger-cli-4.0.4.tgz",
-          "integrity": "sha512-hdDT3B6GLVovCsRZYDi3+wMcB1HfetTU20l2DC8zD3iFRNMC6QNAZG5fo/6PYeHWBEv7ri4MvnlKodhNB0nt7g==",
-          "requires": {
-            "@apidevtools/swagger-parser": "^10.0.1",
-            "chalk": "^4.1.0",
-            "js-yaml": "^3.14.0",
-            "yargs": "^15.4.1"
-          }
-        }
-      }
-    },
-    "validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-    },
-    "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
-    },
-    "yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "requires": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      }
-    },
-    "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
-    "z-schema": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
-      "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
-      "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.6.0"
-      }
-    },
-    "zimmerframe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
-      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
-      "dev": true,
-      "peer": true
-    }
-  }
+	"name": "swagger-deployment",
+	"version": "1.0.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "swagger-deployment",
+			"version": "1.0.0",
+			"license": "ISC",
+			"dependencies": {
+				"swagger-cli": "^4.0.4"
+			},
+			"devDependencies": {
+				"@zeitonline/prettier-config": "^1.1.0"
+			}
+		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+			"integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+			"dependencies": {
+				"@jsdevtools/ono": "^7.1.3",
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^3.13.1"
+			}
+		},
+		"node_modules/@apidevtools/openapi-schemas": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.4.tgz",
+			"integrity": "sha512-ob5c4UiaMYkb24pNhvfSABShAwpREvUGCkqjiz/BX9gKZ32y/S22M+ALIHftTAuv9KsFVSpVdIDzi9ZzFh5TCA==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@apidevtools/swagger-methods": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+		},
+		"node_modules/@apidevtools/swagger-parser": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
+			"integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+			"dependencies": {
+				"@apidevtools/json-schema-ref-parser": "^9.0.6",
+				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/swagger-methods": "^3.0.2",
+				"@jsdevtools/ono": "^7.1.3",
+				"call-me-maybe": "^1.0.1",
+				"z-schema": "^4.2.3"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+		},
+		"node_modules/@sveltejs/acorn-typescript": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
+			"integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"acorn": "^8.9.0"
+			}
+		},
+		"node_modules/@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@zeitonline/prettier-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@zeitonline/prettier-config/-/prettier-config-1.1.0.tgz",
+			"integrity": "sha512-jHU828Wt4tDgBdTLj68BnrtrOBlsX8EsSP80ZIPg4wocgBK0xnkYtqIte8CkFfkKJAZBC1cRsQGtsrHM5lkf9w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prettier-plugin-svelte": "^3.2.7"
+			},
+			"peerDependencies": {
+				"prettier": "^3.2.0"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+			"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+			"dependencies": {
+				"@types/color-name": "^1.1.1",
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/aria-query": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/axobject-query": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+		},
+		"node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"optional": true
+		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"node_modules/esm-env": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/esrap": {
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
+			"integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-reference": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.6"
+			}
+		},
+		"node_modules/js-yaml": {
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/locate-character": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.17",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+			"integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/prettier-plugin-svelte": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
+			"integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"prettier": "^3.0.0",
+				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"node_modules/string-width": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"dependencies": {
+				"ansi-regex": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/svelte": {
+			"version": "5.25.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.25.8.tgz",
+			"integrity": "sha512-yRmjmT5rgCZUMfCKS5varGlSe/nQyr2oClyIirbBChfTFc00YjVAyVWo1zOH74La3hi5KRSkNJKncyJ04PwIYA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.3.0",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@types/estree": "^1.0.5",
+				"acorn": "^8.12.1",
+				"aria-query": "^5.3.1",
+				"axobject-query": "^4.1.0",
+				"clsx": "^2.1.1",
+				"esm-env": "^1.2.1",
+				"esrap": "^1.4.6",
+				"is-reference": "^3.0.3",
+				"locate-character": "^3.0.0",
+				"magic-string": "^0.30.11",
+				"zimmerframe": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/swagger-cli": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/swagger-cli/-/swagger-cli-4.0.4.tgz",
+			"integrity": "sha512-Cp8YYuLny3RJFQ4CvOBTaqmOOgYsem52dPx1xM5S4EUWFblIh2Q8atppMZvXKUr1e9xH5RwipYpmdUzdPcxWcA==",
+			"dependencies": {
+				"@apidevtools/swagger-cli": "4.0.4"
+			},
+			"bin": {
+				"swagger-cli": "swagger-cli.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/swagger-cli/node_modules/@apidevtools/swagger-cli": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-cli/-/swagger-cli-4.0.4.tgz",
+			"integrity": "sha512-hdDT3B6GLVovCsRZYDi3+wMcB1HfetTU20l2DC8zD3iFRNMC6QNAZG5fo/6PYeHWBEv7ri4MvnlKodhNB0nt7g==",
+			"dependencies": {
+				"@apidevtools/swagger-parser": "^10.0.1",
+				"chalk": "^4.1.0",
+				"js-yaml": "^3.14.0",
+				"yargs": "^15.4.1"
+			},
+			"bin": {
+				"swagger-cli": "bin/swagger-cli.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/validator": {
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+			"integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+		},
+		"node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/z-schema": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
+			"integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+			"dependencies": {
+				"lodash.get": "^4.4.2",
+				"lodash.isequal": "^4.5.0",
+				"validator": "^13.6.0"
+			},
+			"bin": {
+				"z-schema": "bin/z-schema"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			},
+			"optionalDependencies": {
+				"commander": "^2.7.1"
+			}
+		},
+		"node_modules/zimmerframe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		}
+	},
+	"dependencies": {
+		"@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"@apidevtools/json-schema-ref-parser": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+			"integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+			"requires": {
+				"@jsdevtools/ono": "^7.1.3",
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^3.13.1"
+			}
+		},
+		"@apidevtools/openapi-schemas": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.4.tgz",
+			"integrity": "sha512-ob5c4UiaMYkb24pNhvfSABShAwpREvUGCkqjiz/BX9gKZ32y/S22M+ALIHftTAuv9KsFVSpVdIDzi9ZzFh5TCA=="
+		},
+		"@apidevtools/swagger-methods": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+		},
+		"@apidevtools/swagger-parser": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
+			"integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+			"requires": {
+				"@apidevtools/json-schema-ref-parser": "^9.0.6",
+				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/swagger-methods": "^3.0.2",
+				"@jsdevtools/ono": "^7.1.3",
+				"call-me-maybe": "^1.0.1",
+				"z-schema": "^4.2.3"
+			}
+		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/set-array": "^1.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"peer": true
+		},
+		"@jridgewell/set-array": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+			"dev": true,
+			"peer": true
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"dev": true,
+			"peer": true
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+		},
+		"@sveltejs/acorn-typescript": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
+			"integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+			"dev": true,
+			"peer": true,
+			"requires": {}
+		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
+		"@types/estree": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+			"dev": true,
+			"peer": true
+		},
+		"@zeitonline/prettier-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@zeitonline/prettier-config/-/prettier-config-1.1.0.tgz",
+			"integrity": "sha512-jHU828Wt4tDgBdTLj68BnrtrOBlsX8EsSP80ZIPg4wocgBK0xnkYtqIte8CkFfkKJAZBC1cRsQGtsrHM5lkf9w==",
+			"dev": true,
+			"requires": {
+				"prettier-plugin-svelte": "^3.2.7"
+			}
+		},
+		"acorn": {
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"dev": true,
+			"peer": true
+		},
+		"ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+		},
+		"ansi-styles": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+			"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+			"requires": {
+				"@types/color-name": "^1.1.1",
+				"color-convert": "^2.0.1"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"aria-query": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"dev": true,
+			"peer": true
+		},
+		"axobject-query": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+			"dev": true,
+			"peer": true
+		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
+		"camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+		},
+		"chalk": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"requires": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"dev": true,
+			"peer": true
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+		},
+		"commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"optional": true
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"esm-env": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+			"dev": true,
+			"peer": true
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+		},
+		"esrap": {
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
+			"integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			}
+		},
+		"find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"requires": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			}
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+		},
+		"is-reference": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@types/estree": "^1.0.6"
+			}
+		},
+		"js-yaml": {
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"locate-character": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+			"dev": true,
+			"peer": true
+		},
+		"locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"requires": {
+				"p-locate": "^4.1.0"
+			}
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"magic-string": {
+			"version": "0.30.17",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/sourcemap-codec": "^1.5.0"
+			}
+		},
+		"p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"requires": {
+				"p-limit": "^2.2.0"
+			}
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+		},
+		"path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+		},
+		"prettier": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+			"integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+			"dev": true,
+			"peer": true
+		},
+		"prettier-plugin-svelte": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
+			"integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
+			"dev": true,
+			"requires": {}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"string-width": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"requires": {
+				"ansi-regex": "^5.0.0"
+			}
+		},
+		"supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
+		},
+		"svelte": {
+			"version": "5.25.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.25.8.tgz",
+			"integrity": "sha512-yRmjmT5rgCZUMfCKS5varGlSe/nQyr2oClyIirbBChfTFc00YjVAyVWo1zOH74La3hi5KRSkNJKncyJ04PwIYA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@ampproject/remapping": "^2.3.0",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@types/estree": "^1.0.5",
+				"acorn": "^8.12.1",
+				"aria-query": "^5.3.1",
+				"axobject-query": "^4.1.0",
+				"clsx": "^2.1.1",
+				"esm-env": "^1.2.1",
+				"esrap": "^1.4.6",
+				"is-reference": "^3.0.3",
+				"locate-character": "^3.0.0",
+				"magic-string": "^0.30.11",
+				"zimmerframe": "^1.1.2"
+			}
+		},
+		"swagger-cli": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/swagger-cli/-/swagger-cli-4.0.4.tgz",
+			"integrity": "sha512-Cp8YYuLny3RJFQ4CvOBTaqmOOgYsem52dPx1xM5S4EUWFblIh2Q8atppMZvXKUr1e9xH5RwipYpmdUzdPcxWcA==",
+			"requires": {
+				"@apidevtools/swagger-cli": "4.0.4"
+			},
+			"dependencies": {
+				"@apidevtools/swagger-cli": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/@apidevtools/swagger-cli/-/swagger-cli-4.0.4.tgz",
+					"integrity": "sha512-hdDT3B6GLVovCsRZYDi3+wMcB1HfetTU20l2DC8zD3iFRNMC6QNAZG5fo/6PYeHWBEv7ri4MvnlKodhNB0nt7g==",
+					"requires": {
+						"@apidevtools/swagger-parser": "^10.0.1",
+						"chalk": "^4.1.0",
+						"js-yaml": "^3.14.0",
+						"yargs": "^15.4.1"
+					}
+				}
+			}
+		},
+		"validator": {
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+			"integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
+		"y18n": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+		},
+		"yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"requires": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			}
+		},
+		"yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"requires": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
+		},
+		"z-schema": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
+			"integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+			"requires": {
+				"commander": "^2.7.1",
+				"lodash.get": "^4.4.2",
+				"lodash.isequal": "^4.5.0",
+				"validator": "^13.6.0"
+			}
+		},
+		"zimmerframe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+			"dev": true,
+			"peer": true
+		}
+	}
 }

--- a/docs/api/package-lock.json
+++ b/docs/api/package-lock.json
@@ -10,6 +10,24 @@
       "license": "ISC",
       "dependencies": {
         "swagger-cli": "^4.0.4"
+      },
+      "devDependencies": {
+        "@zeitonline/prettier-config": "^1.1.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -48,15 +66,119 @@
         "z-schema": "^4.2.3"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
+      "integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@zeitonline/prettier-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@zeitonline/prettier-config/-/prettier-config-1.1.0.tgz",
+      "integrity": "sha512-jHU828Wt4tDgBdTLj68BnrtrOBlsX8EsSP80ZIPg4wocgBK0xnkYtqIte8CkFfkKJAZBC1cRsQGtsrHM5lkf9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-plugin-svelte": "^3.2.7"
+      },
+      "peerDependencies": {
+        "prettier": "^3.2.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -84,6 +206,28 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/call-me-maybe": {
@@ -121,6 +265,17 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -156,6 +311,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -166,6 +329,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esrap": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
+      "integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "node_modules/find-up": {
@@ -204,6 +378,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
@@ -215,6 +400,14 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -236,6 +429,17 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -273,6 +477,34 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
+      "integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
       }
     },
     "node_modules/require-directory": {
@@ -331,6 +563,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.25.8",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.25.8.tgz",
+      "integrity": "sha512-yRmjmT5rgCZUMfCKS5varGlSe/nQyr2oClyIirbBChfTFc00YjVAyVWo1zOH74La3hi5KRSkNJKncyJ04PwIYA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@types/estree": "^1.0.5",
+        "acorn": "^8.12.1",
+        "aria-query": "^5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^1.4.6",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/swagger-cli": {
@@ -446,9 +705,28 @@
       "optionalDependencies": {
         "commander": "^2.7.1"
       }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     }
   },
   "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "@apidevtools/json-schema-ref-parser": {
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
@@ -482,15 +760,90 @@
         "z-schema": "^4.2.3"
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "peer": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "peer": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "peer": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "@sveltejs/acorn-typescript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
+      "integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/estree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "dev": true,
+      "peer": true
+    },
+    "@zeitonline/prettier-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@zeitonline/prettier-config/-/prettier-config-1.1.0.tgz",
+      "integrity": "sha512-jHU828Wt4tDgBdTLj68BnrtrOBlsX8EsSP80ZIPg4wocgBK0xnkYtqIte8CkFfkKJAZBC1cRsQGtsrHM5lkf9w==",
+      "dev": true,
+      "requires": {
+        "prettier-plugin-svelte": "^3.2.7"
+      }
+    },
+    "acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "peer": true
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -513,6 +866,20 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "peer": true
+    },
+    "axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "peer": true
     },
     "call-me-maybe": {
       "version": "1.0.1",
@@ -543,6 +910,13 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "peer": true
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -572,10 +946,27 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "peer": true
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esrap": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
+      "integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      }
     },
     "find-up": {
       "version": "4.1.0",
@@ -601,6 +992,16 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
+    "is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/estree": "^1.0.6"
+      }
+    },
     "js-yaml": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
@@ -609,6 +1010,13 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "peer": true
     },
     "locate-path": {
       "version": "5.0.0",
@@ -627,6 +1035,16 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
     },
     "p-limit": {
       "version": "2.3.0",
@@ -653,6 +1071,20 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+    },
+    "prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "peer": true
+    },
+    "prettier-plugin-svelte": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
+      "integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
+      "dev": true,
+      "requires": {}
     },
     "require-directory": {
       "version": "2.1.1",
@@ -698,6 +1130,29 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "requires": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "svelte": {
+      "version": "5.25.8",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.25.8.tgz",
+      "integrity": "sha512-yRmjmT5rgCZUMfCKS5varGlSe/nQyr2oClyIirbBChfTFc00YjVAyVWo1zOH74La3hi5KRSkNJKncyJ04PwIYA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@ampproject/remapping": "^2.3.0",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@types/estree": "^1.0.5",
+        "acorn": "^8.12.1",
+        "aria-query": "^5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^1.4.6",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
       }
     },
     "swagger-cli": {
@@ -783,6 +1238,13 @@
         "lodash.isequal": "^4.5.0",
         "validator": "^13.6.0"
       }
+    },
+    "zimmerframe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+      "dev": true,
+      "peer": true
     }
   }
 }

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -1,15 +1,18 @@
 {
-  "name": "swagger-deployment",
-  "version": "1.0.0",
-  "description": "",
-  "private": true,
-  "dependencies": {
-    "swagger-cli": "^4.0.4"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "devDependencies": {
-    "@zeitonline/prettier-config": "^1.1.0"
-  }
+	"name": "swagger-deployment",
+	"version": "1.0.0",
+	"description": "",
+	"private": true,
+	"dependencies": {
+		"swagger-cli": "^4.0.4"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"scripts": {
+		"format": "prettier --write ."
+	},
+	"devDependencies": {
+		"@zeitonline/prettier-config": "^1.1.0"
+	}
 }

--- a/docs/api/package.json
+++ b/docs/api/package.json
@@ -8,5 +8,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "@zeitonline/prettier-config": "^1.1.0"
+  }
 }

--- a/docs/api/prettier.config.js
+++ b/docs/api/prettier.config.js
@@ -9,4 +9,14 @@ const zonPrettierConfig = require('@zeitonline/prettier-config');
  */
 module.exports = {
 	...zonPrettierConfig,
+	overrides: [
+		{
+			files: ['*.{yaml,yml}'],
+			options: {
+				singleQuote: false,
+				useTabs: false,
+				tabWidth: 2,
+			},
+		},
+	],
 };

--- a/docs/api/prettier.config.js
+++ b/docs/api/prettier.config.js
@@ -1,0 +1,12 @@
+const zonPrettierConfig = require('@zeitonline/prettier-config');
+
+/**
+ * Note: this picks up the .editorconfig and overrides/extends it.
+ * The .editorconfig that should be used can be found at:
+ * https://github.com/ZeitOnline/frontend-code-style/blob/main/.editorconfig
+ *
+ * @type {import('prettier').Options}
+ */
+module.exports = {
+	...zonPrettierConfig,
+};


### PR DESCRIPTION
Führt `@zeitonline/prettier-config` ein und ersetzt die `.editorconfig` durch die aus [ZeitOnline/frontend-code-style](https://github.com/ZeitOnline/frontend-code-style).