### PR TITLE
feat: add follow type to OpenAPI spec

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -947,6 +947,11 @@ components:
         bookmarkable:
           type: boolean
           example: true
+        followType:
+          type: string
+          enum:
+            - podcast
+            - bookmark
         adControllerPageInfo:
           $ref: "#/components/schemas/AdControllerPageInfo"
         trackingData:


### PR DESCRIPTION
### Beschreibung
In diesem PR wird in der `openapi`-Spec die Möglichkeit hinzugefügt, `followType` mitzugeben bei einer CP.
### Refs
Refs: ENG-201
Friedbert: https://github.com/ZeitOnline/zeit.web/pull/8931
### Gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExN243NG1jYmU0cjc3dnZqMGdldmVvejl5eW1iYmRwYzA0bXY2MXVrZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Cmr1OMJ2FN0B2/giphy.gif)