### PR TITLE
allow new "audio-filters" area

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1732,6 +1732,7 @@ components:
             layout:
               type: string
               enum:
+                - audio-filters
                 - dossier
                 - duo
                 - headed


### PR DESCRIPTION
The app should show filters on `audio-filters` areas.
![Podcastserienseite](https://github.com/user-attachments/assets/6139ae31-866b-40ee-bf74-19a15c1fcab8)
