### PR TITLE
allow zon-teaser-cell

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1466,6 +1466,7 @@ components:
                 - audio-playlist-m-cover
                 - audio-playlist-tile-l
                 - audio-playlist-tile-l-cover
+                - zon-teaser-cell
                 - zon-teaser-classic
                 - zon-teaser-cover
                 - zon-teaser-panorama


### PR DESCRIPTION
zon-teaser-cell will be used to show authors in podcast cps. Let's allow it in ZAPPI...