### PR TITLE
Updatallow audio-listitem-xs

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1516,6 +1516,7 @@ components:
                 - audio-poster-l
                 - audio-tile-s-collapsed
                 - audio-tile-m-collapsed
+                - audio-listitem-xs
                 - audio-listitem-xs-cover
                 - audio-listitem-s-expanded
                 - audio-listitem-m-expanded


### PR DESCRIPTION
What used to be a zon-teaser-list in ZAPPI will now become a audio-listitem-xs