### PR TITLE
ES-290: Add CenterpagePodcastMetadata schema

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -939,7 +939,7 @@ components:
           following_type:
             description: Set to 'podcast' when following a podcast on the Podcast-Series-CP. In all other cases, set to 'bookmark'. If set to null, it defaults to 'bookmark'.
             type: string
-            example: 'bookmark'
+            example: "bookmark"
             enum:
               - bookmark
               - podcast
@@ -1058,22 +1058,24 @@ components:
               - $ref: "#/components/schemas/CenterpageHeader"
               - $ref: "#/components/schemas/CenterpageMarkup"
               - $ref: "#/components/schemas/CenterpageExtra"
-            discriminator:
-              propertyName: type
-              mapping:
-                region: "#/components/schemas/CenterpageRegion"
-                area: "#/components/schemas/CenterpageArea"
-                teaser: "#/components/schemas/CenterpageTeaser"
-                teaser-author: "#/components/schemas/CenterpageTeaserAuthor"
-                teaser-gallery: "#/components/schemas/CenterpageTeaserGallery"
-                teaser-video: "#/components/schemas/CenterpageTeaserVideo"
-                teaser-podcast: "#/components/schemas/CenterpageTeaserPodcast"
-                teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
-                html: "#/components/schemas/CenterpageModuleHTML"
-                adplace: "#/components/schemas/CenterpageAdplace"
-                header: "#/components/schemas/CenterpageHeader"
-                markup: "#/components/schemas/CenterpageMarkup"
-                cpextra: "#/components/schemas/CenterpageExtra"
+              - $ref: "#/components/schemas/CenterpagePodcastMetadata"
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    region: "#/components/schemas/CenterpageRegion"
+                    area: "#/components/schemas/CenterpageArea"
+                    teaser: "#/components/schemas/CenterpageTeaser"
+                    teaser-author: "#/components/schemas/CenterpageTeaserAuthor"
+                    teaser-gallery: "#/components/schemas/CenterpageTeaserGallery"
+                    teaser-video: "#/components/schemas/CenterpageTeaserVideo"
+                    teaser-podcast: "#/components/schemas/CenterpageTeaserPodcast"
+                    teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
+                    html: "#/components/schemas/CenterpageModuleHTML"
+                    adplace: "#/components/schemas/CenterpageAdplace"
+                    header: "#/components/schemas/CenterpageHeader"
+                    markup: "#/components/schemas/CenterpageMarkup"
+                    cpextra: "#/components/schemas/CenterpageExtra"
+                    podcastmetadata: "#/components/schemas/CenterpagePodcastMetadata"
 
     CenterpageElementId:
       type: string
@@ -1097,6 +1099,7 @@ components:
         - header
         - markup
         - cpextra
+        - podcastmetadata
       description: "Type of the cp element"
 
     CenterpageMetadataBase:
@@ -1149,10 +1152,6 @@ components:
                 - podcast
               description: "Always 'podcast' for podcast series"
               example: "podcast"
-            releaseFrequency:
-              type: string
-              nullable: true
-              example: "Täglich um 16 Uhr"
 
     AdControllerPageInfo:
       type: object
@@ -1909,6 +1908,7 @@ components:
                   - $ref: "#/components/schemas/CenterpageTeaserAudio"
                   - $ref: "#/components/schemas/CenterpageModuleHTML"
                   - $ref: "#/components/schemas/CenterpageExtra"
+                  - $ref: "#/components/schemas/CenterpagePodcastMetadata"
                 discriminator:
                   propertyName: type
                   mapping:
@@ -1920,6 +1920,7 @@ components:
                     teaser-audio: "#/components/schemas/CenterpageTeaserAudio"
                     html: "#/components/schemas/CenterpageModuleHTML"
                     cpextra: "#/components/schemas/CenterpageExtra"
+                    podcastmetadata: "#/components/schemas/CenterpagePodcastMetadata"
             trackingData:
               type: object
               properties:
@@ -1997,6 +1998,121 @@ components:
         cpextra:
           description: "The content type this CPExtra represents"
           type: string
+
+    CenterpagePodcastMetadata:
+      description: "A block containing various metadata for a podcast series."
+      allOf:
+        - $ref: "#/components/schemas/CenterpageElement"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - podcastmetadata
+            title:
+              type: string
+            items:
+              type: array
+              description: "A list of metadata blocks. The order is determined by the backend."
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/PodcastMetadataDescription"
+                  - $ref: "#/components/schemas/PodcastMetadataDistributionChannels"
+                  - $ref: "#/components/schemas/PodcastMetadataReleaseFrequency"
+                  - $ref: "#/components/schemas/PodcastMetadataContactEmail"
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    description: "#/components/schemas/PodcastMetadataDescription"
+                    distribution_channels: "#/components/schemas/PodcastMetadataDistributionChannels"
+                    release_frequency: "#/components/schemas/PodcastMetadataReleaseFrequency"
+                    contact_email: "#/components/schemas/PodcastMetadataContactEmail"
+
+    PodcastMetadataBase:
+      type: object
+      required:
+        - type
+        - title
+      properties:
+        type:
+          type: string
+          description: "Discriminator for the podcast metadata block type"
+        title:
+          type: string
+
+    PodcastMetadataDescription:
+      allOf:
+        - $ref: "#/components/schemas/PodcastMetadataBase"
+        - type: object
+          required:
+            - content
+          properties:
+            type:
+              type: string
+              enum: [description]
+            content:
+              type: string
+
+    PodcastMetadataDistributionChannels:
+      allOf:
+        - $ref: "#/components/schemas/PodcastMetadataBase"
+        - type: object
+          required:
+            - channels
+          properties:
+            type:
+              type: string
+              enum: [distribution_channels]
+            channels:
+              type: array
+              items:
+                $ref: "#/components/schemas/PodcastMetadataDistributionChannel"
+
+    PodcastMetadataDistributionChannel:
+      type: object
+      required:
+        - id
+        - url
+        - title
+      properties:
+        id:
+          type: string
+          example: "spotify"
+        url:
+          type: string
+          format: uri
+          example: "https://example.com/spotify"
+        title:
+          type: string
+          example: "Spotify"
+
+    PodcastMetadataReleaseFrequency:
+      allOf:
+        - $ref: "#/components/schemas/PodcastMetadataBase"
+        - type: object
+          required:
+            - content
+          properties:
+            type:
+              type: string
+              enum: [release_frequency]
+            content:
+              type: string
+              example: "Täglich um 16 Uhr"
+
+    PodcastMetadataContactEmail:
+      allOf:
+        - $ref: "#/components/schemas/PodcastMetadataBase"
+        - type: object
+          required:
+            - content
+          properties:
+            type:
+              type: string
+              enum: [contact_email]
+            content:
+              type: string
+              example: "podcast@zeit.de"
 
     TabBase:
       required:


### PR DESCRIPTION
Fügt das neue PodcastMetadata CP-Modul hinzu.

Schwester-PR der das neue Schema implementiert: https://github.com/ZeitOnline/zeit.web/pull/9103

Ticket: https://zeit-online.atlassian.net/browse/ES-290

