### PR TITLE
ES-319: Rename CenterpagePodcastMetadata field "items" to "rows"

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -2016,7 +2016,7 @@ components:
                 - podcastmetadata
             title:
               type: string
-            items:
+            rows:
               type: array
               description: "A list of metadata blocks. The order is determined by the backend."
               items:


### PR DESCRIPTION
Umbenennung des `CenterpagePodcastMetadata`-Felds `items` zu `rows`. Details siehe https://github.com/ZeitOnline/zeit.web/pull/9124