### PR TITLE
ES-340: Use consistent naming for followingType

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -111,7 +111,7 @@ paths:
               summary: Only retrieve `following_type` = `bookmarks` (normal bookmarks). This is also the default value.
             only_podcast:
               value: eq.podcast
-              summary: Only retrieve `following_type` = `podcast` (follows for podcast series)
+              summary: Only retrieve `following_type` = `podcast` (followings for podcast series)
         - in: query
           name: category
           required: false
@@ -1112,13 +1112,13 @@ components:
             - podcast_serienseite
           description: "Type of the Centerpage, also used as discriminator for the polymorphic metadata object"
           example: "podcast_serienseite"
-        followType:
+        followingType:
           type: string
           enum:
             - podcast
             - bookmark
             - series
-          description: "Follow type of the Centerpage"
+          description: "Following type of the Centerpage"
           example: "bookmark"
         title:
           type: string
@@ -1145,7 +1145,7 @@ components:
         - $ref: "#/components/schemas/CenterpageMetadataBase"
         - type: object
           properties:
-            followType:
+            followingType:
               type: string
               enum:
                 - podcast


### PR DESCRIPTION
Wir haben festgestellt, dass diese Eigenschaft an verschiedenen Stellen unterschiedlich benannt ist. Dieser PR (und der Schwester-PR in zeit.web – https://github.com/ZeitOnline/zeit.web/pull/9144 ) gleicht das an.

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2QwZHE1b200ZG4yZDV0aWJ0MXM2aTRoaGpjbWR2b2FjNmNjZmZ5ZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/XB8ivbepqnPIwwdVwO/giphy.gif)