### PR TITLE
docs: add info regarding extra `following_type` validation on POST

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -176,7 +176,7 @@ paths:
         "204":
           description: "Saved entry to bookmarks (without returning it)"
         "400":
-          description: "Something went wrong with the request to save bookmark. Check the body for error messages."
+          description: "Something went wrong with the request to save bookmark. This can occur if the `following_type` does not match the content type of the provided UUID. Check the body for error messages."
         "401":
           description: "Unauthorized (to save bookmark)"
         "403":


### PR DESCRIPTION
Dokumentiert die Überprüfung des `following_type` bei POST Requests an `/-/merkl/bookmarks`. Hier ändert sich erstmalig effektiv nix an der API.

Refs: ENG-708, https://github.com/ZeitOnline/zeit.web/pull/9869