### PR TITLE
allow area layout 'headed-carousel-poster-tiny'

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -2156,6 +2156,7 @@ components:
                 - duo
                 - headed
                 - headed-carousel
+                - headed-carousel-poster-tiny
                 - headed-grid
                 - headed-light
                 - headed-fixed-height


### PR DESCRIPTION
This area layout is used to identify zon-teaser-poster teasers that should be rendered in the tiny variant.