### PR TITLE
ZAPP-487: allow teaser layout 'zon-teaser-poster-extension'

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -1816,6 +1816,7 @@ components:
                 - zon-teaser-podcast-small
                 - zon-teaser-podcast-small-plus
                 - zon-teaser-poster
+                - zon-teaser-poster-extension
                 - zon-teaser-poster-pictorial
                 - zon-teaser-printbox
                 - zon-teaser-upright


### PR DESCRIPTION
## Summary
- Add new teaser layout `zon-teaser-poster-extension` to the allowed layouts in CenterpageTeaserBase schema

## Related issue
ZAPP-487